### PR TITLE
fix: double slash in download url

### DIFF
--- a/bin/dvm.js
+++ b/bin/dvm.js
@@ -252,7 +252,7 @@ function get_download_url(version, registry = "denocn") {
     name = "deno_linux_x64.gz";
   }
 
-  return `${url_prefix}/v${version}/${name}`;
+  return `${url_prefix}v${version}/${name}`;
 }
 
 /**


### PR DESCRIPTION

**What is the purpose of this pull request? (put an "X" next to item)**

- [ ] Documentation update
- [x] Bug fix ([template](https://github.com/justjavac/dvm/blob/master/.github/ISSUE_TEMPLATE/bug_report.md))
- [ ] New feature([template](https://github.com/justjavac/dvm/blob/master/.github/ISSUE_TEMPLATE/feature_request.md))
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

**What changes did you make? **

registry url `url_prefix` in registries.json ends with `/`, no more slash need before `v` as below:

```js
`${url_prefix}v${version}/${name}`
```
