### PR TITLE
fix bug where latest versions are not downloading

### DIFF
--- a/bin/dvm.js
+++ b/bin/dvm.js
@@ -248,11 +248,11 @@ function get_download_url(version, registry = "deno") {
   let name;
 
   if (process.platform === "win32") {
-    name = "deno_win_x64.zip";
+    name = "deno-x86_64-pc-windows-msvc.zip";
   } else if (process.platform === "darwin") {
-    name = "deno_osx_x64.gz";
+    name = "deno-x86_64-apple-darwin.zip";
   } else {
-    name = "deno_linux_x64.gz";
+    name = "deno-x86_64-unknown-linux-gnu.zip";
   }
 
   return `${url_prefix}v${version}/${name}`;
@@ -263,7 +263,7 @@ function get_download_url(version, registry = "deno") {
  *
  * @returns {Promise}
  */
-function download(version, registry = "denocn") {
+function download(version, registry = "deno") {
   let url = get_download_url(version, registry);
   I("remote package url: %s", url);
 


### PR DESCRIPTION
ref: https://github.com/justjavac/dvm/issues/16

<!--

Thank you for being interested in dvm!

Have you read dvm's Code of Conduct? https://github.com/justjavac/dvm/blob/master/CODE_OF_CONDUCT.md

Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md
-->

**What is the purpose of this pull request? (put an "X" next to item)**

- [ ] Documentation update
- [x] Bug fix ([template](https://github.com/justjavac/dvm/blob/master/.github/ISSUE_TEMPLATE/bug_report.md))
- [ ] New feature([template](https://github.com/justjavac/dvm/blob/master/.github/ISSUE_TEMPLATE/feature_request.md))
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

**What changes did you make? **

The fix essentially does two things:

1) fix the package names to comply with the latest release package names
2) default to deno instead of denocn as the registry

This will resolve the bug mentioned beloe