### PR TITLE
fix: missing options prevent directory deletion

### DIFF
--- a/bin/dvm.js
+++ b/bin/dvm.js
@@ -409,7 +409,7 @@ function extractDownload(filePath, extractedPath) {
     })
     .catch((err) => {
       console.error("Error extracting archive");
-      fs.rmdirSync(extractedPath);
+      fs.rmdirSync(extractedPath, { recursive: true });
       console.error(err);
     });
 }


### PR DESCRIPTION
<!--

Thank you for being interested in dvm!

Have you read dvm's Code of Conduct? https://github.com/justjavac/dvm/blob/master/CODE_OF_CONDUCT.md

Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

-->

**What is the purpose of this pull request? (put an "X" next to item)**

- [ ] Documentation update
- [x] Bug fix ([template](https://github.com/justjavac/dvm/blob/master/.github/ISSUE_TEMPLATE/bug_report.md))
- [ ] New feature([template](https://github.com/justjavac/dvm/blob/master/.github/ISSUE_TEMPLATE/feature_request.md))
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

**What changes did you make? **
added necessary options to rmdirSync for macos