### PR TITLE
feat: Support changing dvm root by DVM_DIR env

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,19 +7,23 @@ use std::fs;
 use std::path::PathBuf;
 
 pub fn get_dvm_root() -> PathBuf {
-  // Note: on Windows, the $HOME environment variable may be set by users or by
-  // third party software, but it is non-standard and should not be relied upon.
-  let home_env_var = if cfg!(windows) { "USERPROFILE" } else { "HOME" };
-  let mut home_path = match env::var_os(home_env_var).map(PathBuf::from) {
-    Some(home_path) => home_path,
+  match env::var_os("DVM_DIR").map(PathBuf::from) {
+    Some(dvm_dir) => dvm_dir,
     None => {
-      // Use temp dir
-      TempDir::new().unwrap().into_path()
+      // Note: on Windows, the $HOME environment variable may be set by users or by
+      // third party software, but it is non-standard and should not be relied upon.
+      let home_env_var = if cfg!(windows) { "USERPROFILE" } else { "HOME" };
+      let mut home_path = match env::var_os(home_env_var).map(PathBuf::from) {
+        Some(home_path) => home_path,
+        None => {
+          // Use temp dir
+          TempDir::new().unwrap().into_path()
+        }
+      };
+      home_path.push(".dvm");
+      home_path
     }
-  };
-
-  home_path.push(".dvm");
-  home_path
+  }
 }
 
 pub fn get_exe_path(version: &Version) -> PathBuf {


### PR DESCRIPTION
dvm root is hardcoded to `$HOME/.dvm` , this PR makes it configurable with the `DVM_DIR` environment variable.