### PR TITLE
Detect aarch64 to support Apple M1

### DIFF
--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -15,7 +15,9 @@ use crate::utils::get_exe_path;
 
 #[cfg(windows)]
 const ARCHIVE_NAME: &str = "deno-x86_64-pc-windows-msvc.zip";
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+const ARCHIVE_NAME: &str = "deno-aarch64-apple-darwin.zip";
+#[cfg(all(target_os = "macos", target_arch = "x86_64"))]
 const ARCHIVE_NAME: &str = "deno-x86_64-apple-darwin.zip";
 #[cfg(target_os = "linux")]
 const ARCHIVE_NAME: &str = "deno-x86_64-unknown-linux-gnu.zip";


### PR DESCRIPTION
This commit is intended to get the ball rolling to support Apple M1.

- [x] modify dvm src to download aarch64 binaries (`#[cfg(target_arch = "aarch64")]`)
- [ ] modify GitHub Actions script to cross-compile a target for aarch64
- [ ] modify install script to install the aarch64 target when detected

Related issue: #51

