### PR TITLE
refactor: rename command `use` to `switch`

### DIFF
--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 // Copyright 2020-2021 justjavac. All rights reserved. MIT license.
-use super::use_version;
+use super::switch;
 use crate::utils::{deno_bin_path, dvm_root, is_china_mainland};
 use anyhow::Result;
 use semver_parser::version::{parse as semver_parse, Version};
@@ -40,7 +40,7 @@ pub fn exec(no_use: bool, version: Option<String>) -> Result<()> {
   }
 
   if !no_use {
-    use_version::use_this_bin_path(&exe_path, &install_version)?;
+    switch::use_this_bin_path(&exe_path, &install_version)?;
   }
 
   Ok(())

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,5 +2,6 @@ pub mod completions;
 pub mod info;
 pub mod install;
 pub mod list;
+pub mod switch;
 pub mod uninstall;
-pub mod use_version;
+pub mod r#use;

--- a/src/commands/use.rs
+++ b/src/commands/use.rs
@@ -1,0 +1,6 @@
+use anyhow::Result;
+
+pub fn exec(_version: String) -> Result<()> {
+  eprintln!("This command is not implemented yet");
+  std::process::exit(1);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,10 +72,18 @@ enum Commands {
     version: Option<String>,
   },
 
-  #[clap(about = "Use a given version")]
+  #[clap(about = "Switch to a given version which is locally installed, it's guaranteed to not access the internet")]
+  Switch {
+    #[clap(help = "The version to switch")]
+    version: String,
+  },
+
+  #[clap(
+    about = "Use a given version or a special tag, automatically install when the given version is not installed. If the version you gave is `latest`, dvm will always tracking the latest version and automatically upgrade deno to the latest version every time you run deno (not implemented yet)"
+  )]
   Use {
-    #[clap(help = "The version to install")]
-    version: Option<String>,
+    #[clap(help = "The version to use, or a special tag `latest`")]
+    version: String,
   },
 }
 
@@ -89,7 +97,8 @@ pub fn main() {
     Commands::List => commands::list::exec(),
     Commands::ListRemote => commands::list::exec_remote(),
     Commands::Uninstall { version } => commands::uninstall::exec(version),
-    Commands::Use { version } => commands::use_version::exec(version),
+    Commands::Switch { version } => commands::switch::exec(version),
+    Commands::Use { version } => commands::r#use::exec(version),
   };
 
   if let Err(err) = result {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use semver_parser::version::{parse as semver_parse, Version};
 use std::env;
 use std::path::PathBuf;
@@ -54,4 +55,19 @@ pub fn is_china_mainland() -> bool {
   }
 
   String::from_utf16_lossy(&buf).starts_with("zh-CN")
+}
+
+#[allow(dead_code)]
+pub fn get_latest_version() -> Result<Version> {
+  println!("Checking for latest version");
+  let response = if is_china_mainland() {
+    tinyget::get("https://dl.deno.js.cn/release-latest.txt").send()?
+  } else {
+    tinyget::get("https://dl.deno.land/release-latest.txt").send()?
+  };
+
+  let body = response.as_str()?;
+  let v = body.trim().replace('v', "");
+  println!("The latest version is v{}", &v);
+  Ok(semver_parse(&v).unwrap())
 }


### PR DESCRIPTION
Rename the `use` command to `switch` for later use of the `use` command, for example
```bash
dvm use latest # tracking the latest version and automatically upgrade the deno
```