### PR TITLE
chore: change list-remote sorting from descending to ascending

### DIFF
--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -39,7 +39,7 @@ fn sort_semver_version(s1: &str, s2: &str) -> Ordering {
   let v1 = Version::parse(s1).unwrap();
   let v2 = Version::parse(s2).unwrap();
 
-  v1.cmp(&v2)
+  v2.cmp(&v1)
 }
 
 #[cfg(test)]

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -23,7 +23,7 @@ fn print_versions(mut versions: Vec<String>) {
     _ => String::from(""),
   };
 
-  versions.sort_by(|a, b| sort_semver_version(b, a));
+  versions.sort_by(|a, b| sort_semver_version(b, a).reverse());
 
   for v in &versions {
     if *v == current_version {
@@ -39,7 +39,7 @@ fn sort_semver_version(s1: &str, s2: &str) -> Ordering {
   let v1 = Version::parse(s1).unwrap();
   let v2 = Version::parse(s2).unwrap();
 
-  v2.cmp(&v1)
+  v1.cmp(&v2)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
before
<img width="528" alt="image" src="https://user-images.githubusercontent.com/15936231/165017357-34c61612-7048-4143-bf81-693507c3af70.png">
after
<img width="539" alt="image" src="https://user-images.githubusercontent.com/15936231/165017440-620f72ea-9b8d-4559-8d67-013b2c216474.png">


this pr makes more recent versions more close to current prompt line
<img width="322" alt="image" src="https://user-images.githubusercontent.com/15936231/165017532-121d428f-445c-4881-b1a1-e6443b1bdd24.png">
