### PR TITLE
refactor: use command now use hardlink instead of copying and more

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,12 +589,12 @@ dependencies = [
 
 [[package]]
 name = "set_env"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bdfcc79c3db6e2a3dc37b8f84811943a2529d53d781381a72f00a9b11fb4976"
+checksum = "0ba0e1956022d2b73e289cd009bcc9d95ecbdddf780150bcec9d48337acbb4eb"
 dependencies = [
  "dirs",
- "windows",
+ "winreg",
 ]
 
 [[package]]
@@ -734,44 +734,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.35.0"
+name = "winreg"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08746b4b7ac95f708b3cccceb97b7f9a21a8916dd47fc99b0e6aaf7208f26fd7"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "winapi",
 ]
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3bc5134e8ce0da5d64dcec3529793f1d33aee5a51fc2b4662e0f881dd463e6"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0343a6f35bf43a07b009b8591b78b10ea03de86b06f48e28c96206cd0f453b50"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1acdcbf4ca63d8e7a501be86fee744347186275ec2754d129ddeab7a1e3a02e4"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "893c0924c5a990ec73cd2264d1c0cba1773a929e1a3f5dbccffd769f8c4edebb"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a29bd61f32889c822c99a8fdf2e93378bd2fae4d7efd2693fab09fcaaf7eff4b"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,15 +173,8 @@ dependencies = [
  "set_env",
  "tempfile",
  "tinyget",
- "which",
  "winapi",
 ]
-
-[[package]]
-name = "either"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "foreign-types"
@@ -596,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "set_env"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e7e8dc40b4ebf6cf72d2e73a48ae3c5b02947d1784be28398df21e84db8615"
+checksum = "8bdfcc79c3db6e2a3dc37b8f84811943a2529d53d781381a72f00a9b11fb4976"
 dependencies = [
  "dirs",
  "windows",
@@ -708,17 +701,6 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
-
-[[package]]
-name = "which"
-version = "4.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9"
-dependencies = [
- "either",
- "lazy_static",
- "libc",
-]
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "set_env"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ba0e1956022d2b73e289cd009bcc9d95ecbdddf780150bcec9d48337acbb4eb"
+checksum = "0c6fb6f5cbc6061e4fc834e096c1035fc52415bd52eb8aeb9ce02b2dd4f15927"
 dependencies = [
  "dirs",
  "winreg",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "set_env",
  "tempfile",
  "tinyget",
  "which",
@@ -594,6 +595,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "set_env"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9e7e8dc40b4ebf6cf72d2e73a48ae3c5b02947d1784be28398df21e84db8615"
+dependencies = [
+ "dirs",
+ "windows",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,3 +750,46 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08746b4b7ac95f708b3cccceb97b7f9a21a8916dd47fc99b0e6aaf7208f26fd7"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db3bc5134e8ce0da5d64dcec3529793f1d33aee5a51fc2b4662e0f881dd463e6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0343a6f35bf43a07b009b8591b78b10ea03de86b06f48e28c96206cd0f453b50"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1acdcbf4ca63d8e7a501be86fee744347186275ec2754d129ddeab7a1e3a02e4"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "893c0924c5a990ec73cd2264d1c0cba1773a929e1a3f5dbccffd769f8c4edebb"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a29bd61f32889c822c99a8fdf2e93378bd2fae4d7efd2693fab09fcaaf7eff4b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ serde_json = "1.0"
 dirs = "4.0.0"
 phf = { version = "0.10", features = ["macros"] }
 colored = "2.0.0"
-set_env = "1.1.1"
+set_env = "1.2.0"
 
 [target.'cfg(windows)'.dependencies]
 output_vt100 = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ serde_json = "1.0"
 dirs = "4.0.0"
 phf = { version = "0.10", features = ["macros"] }
 colored = "2.0.0"
-set_env = "1.2.0"
+set_env = "1.2.1"
 
 [target.'cfg(windows)'.dependencies]
 output_vt100 = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ clap_complete = "3.1.2"
 semver = "1.0.7"
 tempfile = "3.2.0"
 tinyget = { version = "1.0.1", features = ["https"] }
-which = "4.2.2"
 json_minimal = "0.1.3"
 asserts-rs = "0.2.1"
 serde = { version = "1.0", features = ["derive"] }
@@ -32,7 +31,7 @@ serde_json = "1.0"
 dirs = "4.0.0"
 phf = { version = "0.10", features = ["macros"] }
 colored = "2.0.0"
-set_env = "1.1.0"
+set_env = "1.1.1"
 
 [target.'cfg(windows)'.dependencies]
 output_vt100 = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ serde_json = "1.0"
 dirs = "4.0.0"
 phf = { version = "0.10", features = ["macros"] }
 colored = "2.0.0"
+set_env = "1.1.0"
 
 [target.'cfg(windows)'.dependencies]
 output_vt100 = "0.1.2"

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -2,7 +2,7 @@
 // Copyright 2020-2021 justjavac. All rights reserved. MIT license.
 use super::use_version;
 use crate::consts::DVM_BIN_PATH_PREFIX;
-use crate::utils::{deno_bin_path, dvm_root, is_china_mainland};
+use crate::utils::{deno_version_path, dvm_root, is_china_mainland};
 use anyhow::Result;
 use semver::Version;
 use std::fs;
@@ -31,7 +31,7 @@ pub fn exec(no_use: bool, version: Option<String>) -> Result<()> {
     None => get_latest_version()?,
   };
 
-  let exe_path = deno_bin_path(&install_version);
+  let exe_path = deno_version_path(&install_version);
 
   if exe_path.exists() {
     println!("version v{} is already installed", install_version);
@@ -99,7 +99,7 @@ fn compose_url_to_exec(version: &Version) -> String {
 fn unpack(archive_data: Vec<u8>, version: &Version) -> Result<PathBuf> {
   let dvm_dir = dvm_root().join(format!("{}/{}", DVM_BIN_PATH_PREFIX, version));
   fs::create_dir_all(&dvm_dir)?;
-  let exe_path = deno_bin_path(version);
+  let exe_path = deno_version_path(version);
 
   let archive_ext = Path::new(ARCHIVE_NAME)
     .extension()

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -1,4 +1,4 @@
-use crate::utils::{deno_bin_path, dvm_root};
+use crate::utils::{deno_version_path, dvm_root};
 use crate::version::current_version;
 use anyhow::Result;
 use semver::Version;
@@ -16,7 +16,7 @@ pub fn exec(version: Option<String>) -> Result<()> {
     },
     None => unimplemented!(),
   };
-  let target_exe_path = deno_bin_path(&target_version);
+  let target_exe_path = deno_version_path(&target_version);
 
   if !target_exe_path.exists() {
     eprintln!("deno v{} is not installed.", target_version);

--- a/src/commands/use_version.rs
+++ b/src/commands/use_version.rs
@@ -51,8 +51,8 @@ pub fn exec(meta: &mut DvmMeta, version: Option<String>) -> Result<()> {
       used_version
     );
     std::io::stdout().flush().unwrap();
-    let confirm = stdin().bytes().next().and_then(|it| it.ok()).map(char::from).unwrap();
-    if confirm == '\n' || confirm.to_ascii_lowercase() == 'y' {
+    let confirm = stdin().bytes().next().and_then(|it| it.ok()).map(char::from).unwrap_or_else(|| 'y');
+    if confirm == '\n' || confirm == '\r' || confirm.to_ascii_lowercase() == 'y' {
       install::exec(true, Some(used_version.to_string())).unwrap();
       let version = version.unwrap_or_else(|| version_req.to_string());
       if !is_exact_version(&version) {
@@ -75,6 +75,9 @@ pub fn use_this_bin_path(exe_path: &Path, version: &Version) -> Result<()> {
   let bin_path = deno_bin_path();
   if !bin_path.parent().unwrap().exists() {
     fs::create_dir_all(bin_path.parent().unwrap()).unwrap();
+  }
+  if bin_path.exists() {
+    fs::remove_file(&bin_path)?;
   }
   fs::hard_link(&exe_path, &bin_path)?;
   println!("Now using deno {}", version);

--- a/src/commands/use_version.rs
+++ b/src/commands/use_version.rs
@@ -51,7 +51,12 @@ pub fn exec(meta: &mut DvmMeta, version: Option<String>) -> Result<()> {
       used_version
     );
     std::io::stdout().flush().unwrap();
-    let confirm = stdin().bytes().next().and_then(|it| it.ok()).map(char::from).unwrap_or_else(|| 'y');
+    let confirm = stdin()
+      .bytes()
+      .next()
+      .and_then(|it| it.ok())
+      .map(char::from)
+      .unwrap_or_else(|| 'y');
     if confirm == '\n' || confirm == '\r' || confirm.to_ascii_lowercase() == 'y' {
       install::exec(true, Some(used_version.to_string())).unwrap();
       let version = version.unwrap_or_else(|| version_req.to_string());

--- a/src/commands/use_version.rs
+++ b/src/commands/use_version.rs
@@ -9,11 +9,9 @@ use crate::version::remote_versions;
 use crate::version::{get_latest_version, VersionArg};
 use anyhow::Result;
 use semver::Version;
-use std::env;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
-use which::which;
 
 pub fn exec(meta: &mut DvmMeta, version: Option<String>) -> Result<()> {
   let version_req: VersionArg;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use clap_complete::Shell;
 use clap_derive::{Parser, Subcommand};
 use colored::Colorize;
 use meta::DvmMeta;
+use utils::{dvm_root};
 
 use crate::meta::DEFAULT_ALIAS;
 use crate::utils::deno_bin_path;
@@ -121,9 +122,13 @@ pub fn main() {
   let mut meta = DvmMeta::new();
 
   // TODO(CGQAQ): remove these after add activate and deactivate command
+  // actually set DVM_DIR env var if not exist.
+  let home_path = dvm_root();
+  set_env::set("DVM_DIR", home_path.to_str().unwrap()).unwrap();
   let path = set_env::get("PATH").unwrap();
-  if !path.contains(deno_bin_path().to_str().unwrap()) {
-    set_env::prepend(path, deno_bin_path().to_str().unwrap().to_string()).unwrap();
+  let looking_for = deno_bin_path().parent().unwrap().to_str().unwrap().to_string();
+  if !path.contains(looking_for.as_str()) {
+    set_env::prepend("PATH", looking_for.as_str()).unwrap();
     println!("{}", "Please restart your shell of choice to take effects.".red());
   }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,9 +9,11 @@ pub mod version;
 use clap::{CommandFactory, Parser};
 use clap_complete::Shell;
 use clap_derive::{Parser, Subcommand};
+use colored::Colorize;
 use meta::DvmMeta;
 
 use crate::meta::DEFAULT_ALIAS;
+use crate::utils::deno_bin_path;
 #[cfg(windows)]
 use ctor::*;
 
@@ -117,6 +119,13 @@ pub enum AliasCommands {
 pub fn main() {
   let cli = Cli::parse();
   let mut meta = DvmMeta::new();
+
+  // TODO(CGQAQ): remove these after add activate and deactivate command
+  let path = set_env::get("PATH").unwrap();
+  if !path.contains(deno_bin_path().to_str().unwrap()) {
+    set_env::prepend(path, deno_bin_path().to_str().unwrap().to_string()).unwrap();
+    println!("{}", "Please restart your shell of choice to take effects.".red());
+  }
 
   let result = match cli.command {
     Commands::Completions { shell } => commands::completions::exec(&mut Cli::command(), shell),

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use clap_complete::Shell;
 use clap_derive::{Parser, Subcommand};
 use colored::Colorize;
 use meta::DvmMeta;
-use utils::{dvm_root};
+use utils::dvm_root;
 
 use crate::meta::DEFAULT_ALIAS;
 use crate::utils::deno_bin_path;
@@ -124,7 +124,7 @@ pub fn main() {
   // TODO(CGQAQ): remove these after add activate and deactivate command
   // actually set DVM_DIR env var if not exist.
   let home_path = dvm_root();
-  set_env::set("DVM_DIR", home_path.to_str().unwrap()).unwrap();
+  set_env::check_or_set("DVM_DIR", home_path.to_str().unwrap()).unwrap();
   let path = set_env::get("PATH").unwrap();
   let looking_for = deno_bin_path().parent().unwrap().to_str().unwrap().to_string();
   if !path.contains(looking_for.as_str()) {

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -4,7 +4,7 @@ use crate::utils::{deno_version_path, dvm_root};
 use crate::version::VersionArg;
 use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
-use std::fs::{read_to_string, write, create_dir_all};
+use std::fs::{create_dir_all, read_to_string, write};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 use crate::consts::{DVM_BIN_PATH_PREFIX, REGISTRY_OFFICIAL};
-use crate::utils::{deno_bin_path, dvm_root};
+use crate::utils::{deno_version_path, dvm_root};
 use crate::version::VersionArg;
 use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
@@ -94,7 +94,7 @@ impl DvmMeta {
         if let Ok(mut config) = config {
           let mut i = 0;
           while i < config.versions.len() {
-            if !deno_bin_path(&Version::parse(&config.versions[i].current).unwrap()).exists() {
+            if !deno_version_path(&Version::parse(&config.versions[i].current).unwrap()).exists() {
               config.versions.remove(i);
             } else {
               i += 1;

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -4,7 +4,7 @@ use crate::utils::{deno_version_path, dvm_root};
 use crate::version::VersionArg;
 use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
-use std::fs::{read_to_string, write};
+use std::fs::{read_to_string, write, create_dir_all};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
@@ -225,7 +225,12 @@ impl DvmMeta {
 
   /// write to disk
   pub fn save(&self) {
-    write(DvmMeta::path(), serde_json::to_string_pretty(self).unwrap()).unwrap();
+    let file_path = DvmMeta::path();
+    let dir_path = file_path.parent().unwrap();
+    if !dir_path.exists() {
+      create_dir_all(dir_path).unwrap();
+    }
+    write(file_path, serde_json::to_string_pretty(self).unwrap()).unwrap();
   }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -100,9 +100,6 @@ pub fn dvm_root() -> PathBuf {
         }
       };
       home_path.push(".dvm");
-
-      // actually set DVM_DIR env var if not exist.
-      set_env::set("DVM_DIR", home_path.to_str().unwrap()).unwrap();
       home_path
     }
   }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -100,12 +100,23 @@ pub fn dvm_root() -> PathBuf {
         }
       };
       home_path.push(".dvm");
+
+      // actually set DVM_DIR env var if not exist.
+      set_env::set("DVM_DIR", home_path.to_str().unwrap()).unwrap();
       home_path
     }
   }
 }
 
-pub fn deno_bin_path(version: &Version) -> PathBuf {
+/// CGQAQ: Put hardlink to executable to this file,
+///        and prepend this folder to env when dvm activated.
+pub fn deno_bin_path() -> PathBuf {
+  let dvm_bin_dir = dvm_root().join("bin");
+  let exe_ext = if cfg!(windows) { "exe" } else { "" };
+  dvm_bin_dir.join("deno").with_extension(exe_ext)
+}
+
+pub fn deno_version_path(version: &Version) -> PathBuf {
   let dvm_dir = dvm_root().join(format!("{}/{}", DVM_BIN_PATH_PREFIX, version));
   let exe_ext = if cfg!(windows) { "exe" } else { "" };
   dvm_dir.join("deno").with_extension(exe_ext)


### PR DESCRIPTION
this refactors utilizing `set_env` to prepends dvm bin path ahead of any other deno path in PATH to make it the `default deno executable`.

now `dvm use` will not replace the global one anymore

this pr will make `activate` and `deactivate` command possible

Fixed: #29