### PR TITLE
fix #87: `Lacking the presence of the new cache folder will making DVM doctor command crash`

### DIFF
--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -1,3 +1,4 @@
+use crate::consts::DVM_CACHE_PATH_PREFIX;
 use anyhow::Result;
 use colored::Colorize;
 use std::fs;
@@ -20,6 +21,13 @@ pub fn exec(meta: &mut DvmMeta) -> Result<()> {
   }
 
   // migrating from old dvm cache.
+  let cache_folder = home_path.join(DVM_CACHE_PATH_PREFIX);
+  if !cache_folder.exists() {
+    fs::create_dir_all(cache_folder)?;
+  } else if !home_path.join(DVM_CACHE_PATH_PREFIX).is_dir() {
+    fs::remove_file(cache_folder.clone())?;
+    fs::create_dir_all(cache_folder)?;
+  }
   let list = fs::read_dir(home_path).unwrap();
   for entry in list {
     let entry = entry.unwrap();

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 // Copyright 2020-2021 justjavac. All rights reserved. MIT license.
 use super::use_version;
-use crate::consts::DVM_BIN_PATH_PREFIX;
+use crate::consts::DVM_CACHE_PATH_PREFIX;
 use crate::utils::{deno_version_path, dvm_root, is_china_mainland};
 use anyhow::Result;
 use semver::Version;
@@ -101,7 +101,7 @@ fn compose_url_to_exec(version: &Version) -> String {
 }
 
 fn unpack(archive_data: Vec<u8>, version: &Version) -> Result<PathBuf> {
-  let dvm_dir = dvm_root().join(format!("{}/{}", DVM_BIN_PATH_PREFIX, version));
+  let dvm_dir = dvm_root().join(format!("{}/{}", DVM_CACHE_PATH_PREFIX, version));
   fs::create_dir_all(&dvm_dir)?;
   let exe_path = deno_version_path(version);
 

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -3,4 +3,4 @@ pub const REGISTRY_OFFICIAL: &str = "https://dl.deno.land/";
 pub const REGISTRY_CN: &str = "https://dl.deno.js.cn/";
 pub const REGISTRY_LATEST_RELEASE_PATH: &str = "release-latest.txt";
 
-pub const DVM_BIN_PATH_PREFIX: &str = "versions";
+pub const DVM_CACHE_PATH_PREFIX: &str = "versions";

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-use crate::consts::{DVM_BIN_PATH_PREFIX, REGISTRY_OFFICIAL};
+use crate::consts::{DVM_CACHE_PATH_PREFIX, REGISTRY_OFFICIAL};
 use crate::utils::{deno_version_path, dvm_root};
 use crate::version::VersionArg;
 use semver::{Version, VersionReq};
@@ -111,7 +111,7 @@ impl DvmMeta {
   }
 
   pub fn clean_files(&self) {
-    let bin_path = dvm_root().join(Path::new(DVM_BIN_PATH_PREFIX));
+    let bin_path = dvm_root().join(Path::new(DVM_CACHE_PATH_PREFIX));
     for entry in bin_path.read_dir().expect("read_dir call failed").flatten() {
       if entry.metadata().unwrap().is_dir()
         && !self

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-use crate::consts::DVM_BIN_PATH_PREFIX;
+use crate::consts::DVM_CACHE_PATH_PREFIX;
 use crate::version::VersionArg;
 use anyhow::anyhow;
 use dirs::home_dir;
@@ -120,7 +120,7 @@ pub fn deno_bin_path() -> PathBuf {
 }
 
 pub fn deno_version_path(version: &Version) -> PathBuf {
-  let dvm_dir = dvm_root().join(format!("{}/{}", DVM_BIN_PATH_PREFIX, version));
+  let dvm_dir = dvm_root().join(format!("{}/{}", DVM_CACHE_PATH_PREFIX, version));
   let exe_ext = if cfg!(windows) { "exe" } else { "" };
   dvm_dir.join("deno").with_extension(exe_ext)
 }


### PR DESCRIPTION
Fixed: #87 