### PR TITLE
Fixed MacOS install and added test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,10 @@ jobs:
       - name: Run cargo test
         run: cargo test --locked
 
+      - name: Test install from local file (bash)
+        if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macOS')
+        run: ./install.sh ./target/release/dvm
+
       - name: Pre-release (linux)
         if: startsWith(matrix.os, 'ubuntu')
         run: |

--- a/install.sh
+++ b/install.sh
@@ -13,10 +13,11 @@ fi
 if [ "$OS" = "Windows_NT" ]; then
 	target="x86_64-pc-windows-msvc"
 else
-	case $(uname -s) in
+	case $(uname -sm) in
 	"Darwin x86_64") target="x86_64-apple-darwin" ;;
 	"Darwin arm64") target="aarch64-apple-darwin" ;;
-	*) target="x86_64-unknown-linux-gnu" ;;
+	"Linux x86_64") target="x86_64-unknown-linux-gnu" ;;
+	*) echo "Unsupported OS + CPU combination: $(uname -sm)"; exit 1 ;;
 	esac
 fi
 
@@ -31,11 +32,21 @@ if [ ! -d "$dvm_bin_dir" ]; then
 	mkdir -p "$dvm_bin_dir"
 fi
 
-curl --fail --location --progress-bar --output "$exe.zip" "$dvm_uri"
+if [ "$1" = "" ]; then
+	cd "$dvm_bin_dir"
+	curl --fail --location --progress-bar --output "$exe.zip" "$dvm_uri"
+	unzip -o "$exe.zip"
+	rm "$exe.zip"
+else
+	echo "Install path override detected: $1"
+	if [ ! -f "$1" ]; then
+		echo "File does not exist: $1"
+		exit 1
+	fi
+	cp "$1" "$exe"
+fi
 cd "$dvm_bin_dir"
-unzip -o "$exe.zip"
 chmod +x "$exe"
-rm "$exe.zip"
 
 case $SHELL in
 /bin/zsh) shell_profile=".zshrc" ;;


### PR DESCRIPTION
## Overview

The PR #89 broke `install.sh` script on MacOS for all CPU architectures. This PR fixes that break and adds test to ensure it doesn't happen in the future.

## Related Issues and PRs

1. #89
2. #51

## Changes

1. Fix script issue causing installations to fail on MacOS in `install.sh`.
3. Changed OS+CPU logic to gracefully error in cases of unsupported combinations in `install.sh`.
4. Allowed for `install.sh` to receive an optional argument for installation from a local copy of dvm for easy testing.
5. Updated CI to test that `install.sh` works on MacOS and Linux, via changes in `.github/workflows/ci.yml`.