### PR TITLE
feat. adding --local flag to `use` command

### DIFF
--- a/src/commands/activate.rs
+++ b/src/commands/activate.rs
@@ -9,5 +9,5 @@ pub fn exec(meta: &mut DvmMeta) -> Result<()> {
     std::fs::remove_file(home.join(".deactivated")).unwrap();
   }
 
-  use_version::exec(meta, None)
+  use_version::exec(meta, None, false)
 }

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -46,7 +46,7 @@ pub fn exec(meta: &mut DvmMeta) -> Result<()> {
   }
 
   if !dirs::home_dir().unwrap().join(".dvmrc").exists() {
-    super::use_version::exec(meta, None).unwrap();
+    super::use_version::exec(meta, None, false).unwrap();
   }
 
   println!("{}", "All fixes applied, DVM is ready to use.".green());

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -45,6 +45,7 @@ pub fn exec(no_use: bool, version: Option<String>) -> Result<()> {
       &exe_path,
       &install_version,
       version.unwrap_or_else(|| "latest".to_string()),
+      false,
     )?;
   }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,6 +87,13 @@ enum Commands {
   Use {
     #[clap(help = "The version, semver range or alias to use")]
     version: Option<String>,
+
+    #[clap(
+      short,
+      long,
+      help = "Writing the version to the .dvmrc file of the current directory if present"
+    )]
+    local: bool,
   },
 
   #[clap(about = "Set or unset an alias")]
@@ -135,7 +142,7 @@ pub fn main() {
     Commands::List => commands::list::exec(),
     Commands::ListRemote => commands::list::exec_remote(),
     Commands::Uninstall { version } => commands::uninstall::exec(version),
-    Commands::Use { version } => commands::use_version::exec(&mut meta, version),
+    Commands::Use { version, local } => commands::use_version::exec(&mut meta, version, local),
     Commands::Alias { command } => commands::alias::exec(&mut meta, command),
     Commands::Activate => commands::activate::exec(&mut meta),
     Commands::Deactivate => commands::deactivate::exec(),

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -131,7 +131,7 @@ impl DvmMeta {
   ///   `current` is the current directory that the deno located in
   pub fn set_version_mapping(&mut self, required: String, current: String) {
     println!("{}, {}", &required, current);
-    let result = self.versions.iter().position(|it| it.required == current);
+    let result = self.versions.iter().position(|it| it.required == required);
     if let Some(index) = result {
       self.versions[index] = VersionMapping { required, current };
     } else {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -25,7 +25,7 @@ pub fn update_stub(verison: &str) {
   let mut home = dvm_root();
   home.push("versions");
   home.push(verison);
-  println!("update_stub {}", home.to_str().unwrap());
+  // println!("update_stub {}", home.to_str().unwrap());
   if home.is_dir() {
     home.push(".dvmstub");
     write(home, now().to_string()).unwrap();


### PR DESCRIPTION
This PR added a `--local` flag to the `use` command to tell DVM to write the version metadata to the config file in the current directory.