### PR TITLE
feat: registry

### DIFF
--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -37,7 +37,8 @@ pub fn exec(meta: &mut DvmMeta, command: &str, verison: Option<&str>) -> Result<
 
   if !executable_path.exists() {
     if prompt_request(format!("deno v{} is not installed. do you want to install it?", version).as_str()) {
-      install::exec(true, Some(version.clone())).unwrap_or_else(|_| panic!("Failed to install deno {}", version));
+      install::exec(&meta, true, Some(version.clone()))
+        .unwrap_or_else(|_| panic!("Failed to install deno {}", version));
     } else {
       eprintln!("{}", "No such version found.".red());
       std::process::exit(1);

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -37,8 +37,7 @@ pub fn exec(meta: &mut DvmMeta, command: &str, verison: Option<&str>) -> Result<
 
   if !executable_path.exists() {
     if prompt_request(format!("deno v{} is not installed. do you want to install it?", version).as_str()) {
-      install::exec(meta, true, Some(version.clone()))
-        .unwrap_or_else(|_| panic!("Failed to install deno {}", version));
+      install::exec(meta, true, Some(version.clone())).unwrap_or_else(|_| panic!("Failed to install deno {}", version));
     } else {
       eprintln!("{}", "No such version found.".red());
       std::process::exit(1);

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -37,7 +37,7 @@ pub fn exec(meta: &mut DvmMeta, command: &str, verison: Option<&str>) -> Result<
 
   if !executable_path.exists() {
     if prompt_request(format!("deno v{} is not installed. do you want to install it?", version).as_str()) {
-      install::exec(&meta, true, Some(version.clone()))
+      install::exec(meta, true, Some(version.clone()))
         .unwrap_or_else(|_| panic!("Failed to install deno {}", version));
     } else {
       eprintln!("{}", "No such version found.".red());

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,6 +8,7 @@ pub mod exec;
 pub mod info;
 pub mod install;
 pub mod list;
+pub mod registry;
 pub mod uninstall;
 pub mod upgrade;
 pub mod use_version;

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -11,13 +11,21 @@ pub fn exec(meta: &mut DvmMeta, registry: Option<String>) -> Result<()> {
 
   if registry == "official".to_string() {
     meta.registry = REGISTRY_OFFICIAL.to_string();
+    println!("Registry now set to the official registry \"{}\"", REGISTRY_OFFICIAL);
   } else if registry == "cn".to_string() {
     meta.registry = REGISTRY_CN.to_string();
+    println!(
+      "Registry now set to the CN mirror (that provided by @justjavac) \"{}\"",
+      REGISTRY_CN
+    )
   } else if registry.starts_with("http://") || registry.starts_with("https://") {
     meta.registry = registry;
   } else {
-    eprintln!("{} is not valid URL, please starts with `http` or `https`", registry);
-    eprintln!("registry will not be changed");
+    eprintln!(
+      "The {} is not valid URL, please starts with `http` or `https`",
+      registry
+    );
+    eprintln!("Registry will not be changed");
     process::exit(1)
   }
 

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -7,12 +7,12 @@ use crate::DvmMeta;
 use anyhow::Result;
 
 pub fn exec(meta: &mut DvmMeta, registry: Option<String>) -> Result<()> {
-  let registry = registry.unwrap_or("official".to_string());
+  let registry = registry.unwrap_or_else(|| "official".to_string());
 
-  if registry == "official".to_string() {
+  if registry == *"official" {
     meta.registry = REGISTRY_OFFICIAL.to_string();
     println!("Registry now set to the official registry \"{}\"", REGISTRY_OFFICIAL);
-  } else if registry == "cn".to_string() {
+  } else if registry == *"cn" {
     meta.registry = REGISTRY_CN.to_string();
     println!(
       "Registry now set to the CN mirror (that provided by @justjavac) \"{}\"",

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -1,0 +1,26 @@
+use std::process;
+
+use crate::consts::REGISTRY_CN;
+use crate::consts::REGISTRY_OFFICIAL;
+use crate::DvmMeta;
+
+use anyhow::Result;
+
+pub fn exec(meta: &mut DvmMeta, registry: Option<String>) -> Result<()> {
+  let registry = registry.unwrap_or("official".to_string());
+
+  if registry == "official".to_string() {
+    meta.registry = REGISTRY_OFFICIAL.to_string();
+  } else if registry == "cn".to_string() {
+    meta.registry = REGISTRY_CN.to_string();
+  } else if registry.starts_with("http://") || registry.starts_with("https://") {
+    meta.registry = registry;
+  } else {
+    eprintln!("{} is not valid URL, please starts with `http` or `https`", registry);
+    eprintln!("registry will not be changed");
+    process::exit(1)
+  }
+
+  meta.save();
+  Ok(())
+}

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -13,7 +13,7 @@ pub fn exec(meta: &mut DvmMeta, alias: Option<String>) -> Result<()> {
   if let Some(alias) = alias {
     if alias == "canary" {
       println!("Upgrading {}", alias.bright_black());
-      install::exec(&meta, true, Some(alias)).unwrap();
+      install::exec(meta, true, Some(alias)).unwrap();
       println!("All aliases have been upgraded");
       return Ok(());
     }
@@ -36,12 +36,12 @@ pub fn exec(meta: &mut DvmMeta, alias: Option<String>) -> Result<()> {
           println!("{} is already the latest version", alias);
           std::process::exit(0);
         } else {
-          install::exec(&meta, true, Some(v.to_string())).expect("Install failed");
+          install::exec(meta, true, Some(v.to_string())).expect("Install failed");
         }
       }
       VersionArg::Range(r) => {
         let version = best_version(versions.iter().map(AsRef::as_ref).collect::<Vec<&str>>().as_slice(), r).unwrap();
-        install::exec(&meta, true, Some(version.to_string())).expect("Install failed");
+        install::exec(meta, true, Some(version.to_string())).expect("Install failed");
         meta.set_version_mapping(alias, version.to_string());
       }
     }
@@ -68,11 +68,11 @@ pub fn exec(meta: &mut DvmMeta, alias: Option<String>) -> Result<()> {
         current.bright_red(),
         latest.clone().bright_green()
       );
-      install::exec(&meta, true, Some(latest.clone()))?;
+      install::exec(meta, true, Some(latest.clone()))?;
       meta.set_version_mapping(alias.name, latest);
 
       println!("Upgrading {}", "canary".bright_black());
-      install::exec(&meta, true, Some("canary".to_string())).unwrap();
+      install::exec(meta, true, Some("canary".to_string())).unwrap();
     }
 
     println!("All aliases have been upgraded");

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -13,7 +13,7 @@ pub fn exec(meta: &mut DvmMeta, alias: Option<String>) -> Result<()> {
   if let Some(alias) = alias {
     if alias == "canary" {
       println!("Upgrading {}", alias.bright_black());
-      install::exec(true, Some(alias)).unwrap();
+      install::exec(&meta, true, Some(alias)).unwrap();
       println!("All aliases have been upgraded");
       return Ok(());
     }
@@ -36,12 +36,12 @@ pub fn exec(meta: &mut DvmMeta, alias: Option<String>) -> Result<()> {
           println!("{} is already the latest version", alias);
           std::process::exit(0);
         } else {
-          install::exec(true, Some(v.to_string())).expect("Install failed");
+          install::exec(&meta, true, Some(v.to_string())).expect("Install failed");
         }
       }
       VersionArg::Range(r) => {
         let version = best_version(versions.iter().map(AsRef::as_ref).collect::<Vec<&str>>().as_slice(), r).unwrap();
-        install::exec(true, Some(version.to_string())).expect("Install failed");
+        install::exec(&meta, true, Some(version.to_string())).expect("Install failed");
         meta.set_version_mapping(alias, version.to_string());
       }
     }
@@ -68,11 +68,11 @@ pub fn exec(meta: &mut DvmMeta, alias: Option<String>) -> Result<()> {
         current.bright_red(),
         latest.clone().bright_green()
       );
-      install::exec(true, Some(latest.clone()))?;
+      install::exec(&meta, true, Some(latest.clone()))?;
       meta.set_version_mapping(alias.name, latest);
 
       println!("Upgrading {}", "canary".bright_black());
-      install::exec(true, Some("canary".to_string())).unwrap();
+      install::exec(&meta, true, Some("canary".to_string())).unwrap();
     }
 
     println!("All aliases have been upgraded");

--- a/src/commands/use_version.rs
+++ b/src/commands/use_version.rs
@@ -19,7 +19,7 @@ pub fn exec(meta: &mut DvmMeta, version: Option<String>, local: bool) -> Result<
       let canary_path = deno_canary_path();
       if !canary_path.exists() {
         if prompt_request("deno canary is not installed. do you want to install it?") {
-          install::exec(true, Some("canary".to_string())).unwrap();
+          install::exec(&meta, true, Some("canary".to_string())).unwrap();
           use_canary_bin_path(local).unwrap();
         } else {
           std::process::exit(1);
@@ -72,7 +72,7 @@ pub fn exec(meta: &mut DvmMeta, version: Option<String>, local: bool) -> Result<
 
   if !new_exe_path.exists() {
     if prompt_request(format!("deno v{} is not installed. do you want to install it?", used_version).as_str()) {
-      install::exec(true, Some(used_version.to_string())).unwrap();
+      install::exec(&meta, true, Some(used_version.to_string())).unwrap();
       let temp = version_req.to_string();
       let version = version.as_ref().unwrap_or(&temp);
       if !is_exact_version(version) {

--- a/src/commands/use_version.rs
+++ b/src/commands/use_version.rs
@@ -19,7 +19,7 @@ pub fn exec(meta: &mut DvmMeta, version: Option<String>, local: bool) -> Result<
       let canary_path = deno_canary_path();
       if !canary_path.exists() {
         if prompt_request("deno canary is not installed. do you want to install it?") {
-          install::exec(&meta, true, Some("canary".to_string())).unwrap();
+          install::exec(meta, true, Some("canary".to_string())).unwrap();
           use_canary_bin_path(local).unwrap();
         } else {
           std::process::exit(1);
@@ -72,7 +72,7 @@ pub fn exec(meta: &mut DvmMeta, version: Option<String>, local: bool) -> Result<
 
   if !new_exe_path.exists() {
     if prompt_request(format!("deno v{} is not installed. do you want to install it?", used_version).as_str()) {
-      install::exec(&meta, true, Some(used_version.to_string())).unwrap();
+      install::exec(meta, true, Some(used_version.to_string())).unwrap();
       let temp = version_req.to_string();
       let version = version.as_ref().unwrap_or(&temp);
       if !is_exact_version(version) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,6 +127,12 @@ enum Commands {
 
   #[clap(about = "Clean dvm cache")]
   Clean,
+
+  #[clap(about = "Change registry that dvm fetch from")]
+  Registry {
+    #[clap(help = "The registry to be set, `official`, `cn`, or url you desired")]
+    registry: Option<String>,
+  },
 }
 
 #[derive(Subcommand)]
@@ -156,7 +162,7 @@ pub fn main() {
   let result = match cli.command {
     Commands::Completions { shell } => commands::completions::exec(&mut Cli::command(), shell),
     Commands::Info => commands::info::exec(),
-    Commands::Install { no_use, version } => commands::install::exec(no_use, version),
+    Commands::Install { no_use, version } => commands::install::exec(&meta, no_use, version),
     Commands::List => commands::list::exec(),
     Commands::ListRemote => commands::list::exec_remote(),
     Commands::Uninstall { version } => commands::uninstall::exec(version),
@@ -170,6 +176,7 @@ pub fn main() {
       commands::exec::exec(&mut meta, command.unwrap_or_default().as_str(), verison.as_deref())
     }
     Commands::Clean => commands::clean::exec(&mut meta),
+    Commands::Registry { registry } => commands::registry::exec(&mut meta, registry),
   };
 
   if let Err(err) = result {


### PR DESCRIPTION
This PR adds a new command `registry`

use cases
```bash
dvm registry official # or leave blank to set the registry to the official one (https://dl.deno.land/)
dvm registry cn # set the registry to https://dl.deno.js.cn/
dvm registry [URL] # set the registry to custom url
```

### screenshots

<img width="566" alt="image" src="https://user-images.githubusercontent.com/15936231/178116668-1a485ca0-32ac-41c1-a375-08cf9a22e45e.png">
<img width="476" alt="image" src="https://user-images.githubusercontent.com/15936231/178116810-d94683db-b556-4e18-a35f-0b0fa7b18900.png">
<img width="563" alt="image" src="https://user-images.githubusercontent.com/15936231/178116837-8f03c97f-1d07-4ed3-bf3b-dac0a57880af.png">


<img width="636" alt="image" src="https://user-images.githubusercontent.com/15936231/178116827-f884cf6a-fb74-422e-baea-8fdfa0252cb0.png">
<img width="568" alt="image" src="https://user-images.githubusercontent.com/15936231/178116846-9f03d516-4825-4fc5-92ef-c35f715fd7cc.png">


