### PR TITLE
opt: check whether the alias content is  valid before setting it

### DIFF
--- a/src/commands/alias.rs
+++ b/src/commands/alias.rs
@@ -23,7 +23,7 @@ fn apply_alias_color(a: &str, c: &str) -> ColoredString {
 pub fn exec(meta: &mut DvmMeta, command: AliasCommands) -> Result<()> {
   match command {
     AliasCommands::Set { name, content } => {
-      VersionReq::parse(content.as_str()).expect(format!("unexpected alias content: {}", content).as_str());
+      VersionReq::parse(content.as_str()).unwrap_or_else(|_| panic!("unexpected alias content: {}", content));
       meta.set_alias(name, content);
       Ok(())
     }

--- a/src/commands/alias.rs
+++ b/src/commands/alias.rs
@@ -2,6 +2,7 @@ use crate::{AliasCommands, DvmMeta, DEFAULT_ALIAS};
 use anyhow::Result;
 use colored::{ColoredString, Colorize};
 use phf::phf_map;
+use semver::VersionReq;
 
 const ALIAS_COLORS: phf::Map<&str, (u8, u8, u8)> = phf_map! {
     "lighter" => (0xD1, 0xFA, 0xFF),        // unused
@@ -22,6 +23,7 @@ fn apply_alias_color(a: &str, c: &str) -> ColoredString {
 pub fn exec(meta: &mut DvmMeta, command: AliasCommands) -> Result<()> {
   match command {
     AliasCommands::Set { name, content } => {
+      VersionReq::parse(content.as_str()).expect(format!("unexpected semver content: {}", content).as_str());
       meta.set_alias(name, content);
       Ok(())
     }

--- a/src/commands/alias.rs
+++ b/src/commands/alias.rs
@@ -23,7 +23,7 @@ fn apply_alias_color(a: &str, c: &str) -> ColoredString {
 pub fn exec(meta: &mut DvmMeta, command: AliasCommands) -> Result<()> {
   match command {
     AliasCommands::Set { name, content } => {
-      VersionReq::parse(content.as_str()).expect(format!("unexpected semver content: {}", content).as_str());
+      VersionReq::parse(content.as_str()).expect(format!("unexpected alias content: {}", content).as_str());
       meta.set_alias(name, content);
       Ok(())
     }


### PR DESCRIPTION
在设置别名之前，检查下用户输入的内容是否符合semver规范，不符合则抛出异常。