### PR TITLE
refactor: dvm command `registry`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,12 +38,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bumpalo"
-version = "3.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
-
-[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,21 +48,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chrono"
-version = "0.4.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
-dependencies = [
- "iana-time-zone",
- "js-sys",
- "num-integer",
- "num-traits",
- "time",
- "wasm-bindgen",
- "winapi",
-]
 
 [[package]]
 name = "clap"
@@ -124,16 +94,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
-]
-
-[[package]]
 name = "colored"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,50 +131,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cxx"
-version = "1.0.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97abf9f0eca9e52b7f81b945524e76710e6cb2366aead23b7d4fbf72e281f888"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc32cc5fea1d894b77d269ddb9f192110069a8a9c1f1d441195fba90553dea3"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca220e4794c934dc6b1207c3b42856ad4c302f2df1712e9f8d2eec5afaacf1f"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b846f081361125bfc8dc9d3940c84e1fd83ba54bbca7b17cd29483c828be0704"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "dirs"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,7 +157,6 @@ dependencies = [
  "anyhow",
  "asserts-rs",
  "cfg-if",
- "chrono",
  "clap",
  "clap_complete",
  "clap_derive",
@@ -300,7 +215,7 @@ checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -319,30 +234,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "winapi",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
-dependencies = [
- "cxx",
- "cxx-build",
-]
-
-[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,15 +247,6 @@ name = "itoa"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
-
-[[package]]
-name = "js-sys"
-version = "0.3.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
-dependencies = [
- "wasm-bindgen",
-]
 
 [[package]]
 name = "json_minimal"
@@ -383,15 +265,6 @@ name = "libc"
 version = "0.2.131"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04c3b4822ccebfa39c02fc03d1534441b22ead323fa0f48bb7ddd8e6ba076a40"
-
-[[package]]
-name = "link-cplusplus"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "log"
@@ -418,25 +291,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -666,12 +520,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scratch"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
-
-[[package]]
 name = "security-framework"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,17 +655,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
 name = "tinyget"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -833,12 +670,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -852,69 +683,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
-dependencies = [
- "cfg-if",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
-dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "which"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ colored = "2.0.0"
 native-tls = { version = "0.2.10", features = ["vendored"] }
 set_env = "1.3.4"
 which = "4.2.5"
-chrono = "0.4"
 
 [target.'cfg(windows)'.dependencies]
 output_vt100 = "0.1.3"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,45 +7,45 @@ use clap_derive::{Parser, Subcommand};
 
 use crate::commands;
 use crate::consts::{
-  AFTER_HELP, COMPLETIONS_HELP, REGISTRY_CN, REGISTRY_LIST_CN, REGISTRY_LIST_OFFICIAL, REGISTRY_NAME_CN,
-  REGISTRY_NAME_OFFICIAL, REGISTRY_OFFICIAL,
+    AFTER_HELP, COMPLETIONS_HELP, REGISTRY_CN, REGISTRY_LIST_CN, REGISTRY_LIST_OFFICIAL, REGISTRY_NAME_CN,
+    REGISTRY_NAME_OFFICIAL, REGISTRY_OFFICIAL,
 };
 use crate::meta::DvmMeta;
 
 pub fn cli_parse(meta: &mut DvmMeta) -> Result<Cli, ()> {
-  let args: Vec<String> = env::args().collect();
-  if args.len() > 1 && args[1] == "exec" {
-    if args.len() > 2 {
-      let version: Option<String>;
-      let exec_args: Vec<String>;
-      if args[2] == "--version" || args[2] == "-V" {
-        if args.len() > 3 {
-          version = Some(args[3].clone());
-          exec_args = args[4..].to_vec();
+    let args: Vec<String> = env::args().collect();
+    if args.len() > 1 && args[1] == "exec" {
+        if args.len() > 2 {
+            let version: Option<String>;
+            let exec_args: Vec<String>;
+            if args[2] == "--version" || args[2] == "-V" {
+                if args.len() > 3 {
+                    version = Some(args[3].clone());
+                    exec_args = args[4..].to_vec();
+                } else {
+                    eprintln!("A version should be followed after {}", args[2]);
+                    std::process::exit(1)
+                }
+            } else if args[2].starts_with("--version=") || args[2].starts_with("-V=") {
+                version = Some(
+                    args[2]
+                        .trim_start_matches("-V=")
+                        .trim_start_matches("--version=")
+                        .to_string(),
+                );
+                exec_args = args[3..].to_vec();
+            } else {
+                version = None;
+                exec_args = args[2..].to_vec();
+            }
+            commands::exec::exec(meta, version, exec_args).unwrap();
         } else {
-          eprintln!("A version should be followed after {}", args[2]);
-          std::process::exit(1)
+            commands::exec::exec(meta, None, vec![]).unwrap();
         }
-      } else if args[2].starts_with("--version=") || args[2].starts_with("-V=") {
-        version = Some(
-          args[2]
-            .trim_start_matches("-V=")
-            .trim_start_matches("--version=")
-            .to_string(),
-        );
-        exec_args = args[3..].to_vec();
-      } else {
-        version = None;
-        exec_args = args[2..].to_vec();
-      }
-      commands::exec::exec(meta, version, exec_args).unwrap();
-    } else {
-      commands::exec::exec(meta, None, vec![]).unwrap();
+        return Err(());
     }
-    return Err(());
-  }
 
-  Ok(Cli::parse())
+    Ok(Cli::parse())
 }
 
 #[derive(Parser)]
@@ -53,203 +53,216 @@ pub fn cli_parse(meta: &mut DvmMeta) -> Result<Cli, ()> {
 #[clap(after_help = AFTER_HELP)]
 #[clap(propagate_version = true)]
 pub struct Cli {
-  #[clap(subcommand)]
-  pub command: Commands,
+    #[clap(subcommand)]
+    pub command: Commands,
 }
 
 #[derive(Subcommand)]
 pub enum Commands {
-  #[clap(about = "Generate shell completions")]
-  #[clap(long_about = COMPLETIONS_HELP)]
-  Completions {
-    #[arg(value_enum)]
-    shell: Shell,
-  },
+    #[clap(about = "Generate shell completions")]
+    #[clap(long_about = COMPLETIONS_HELP)]
+    Completions {
+        #[arg(value_enum)]
+        shell: Shell,
+    },
 
-  #[clap(about = "Show dvm info.")]
-  Info,
+    #[clap(about = "Show dvm info.")]
+    Info,
 
-  #[clap(about = "Install deno executable to the given version.")]
-  #[clap(visible_aliases = & ["i", "add"])]
-  Install {
-    #[clap(long, help = "Only install to local, but not use")]
-    no_use: bool,
-    #[clap(help = "The version to install")]
-    version: Option<String>,
-  },
+    #[clap(about = "Install deno executable to the given version.")]
+    #[clap(visible_aliases = & ["i", "add"])]
+    Install {
+        #[clap(long, help = "Only install to local, but not use")]
+        no_use: bool,
+        #[clap(help = "The version to install")]
+        version: Option<String>,
+    },
 
-  #[clap(about = "List all installed versions")]
-  #[clap(visible_aliases = & ["ls", "ll", "la"])]
-  List,
+    #[clap(about = "List all installed versions")]
+    #[clap(visible_aliases = & ["ls", "ll", "la"])]
+    List,
 
-  #[clap(about = "List all released versions")]
-  #[clap(visible_aliases = & ["lr", "ls-remote"])]
-  ListRemote,
+    #[clap(about = "List all released versions")]
+    #[clap(visible_aliases = & ["lr", "ls-remote"])]
+    ListRemote,
 
-  #[clap(about = "Uninstall a given version")]
-  #[clap(visible_aliases = & ["un", "unlink", "rm", "remove"])]
-  Uninstall {
-    #[clap(help = "The version to install")]
-    version: Option<String>,
-  },
+    #[clap(about = "Uninstall a given version")]
+    #[clap(visible_aliases = & ["un", "unlink", "rm", "remove"])]
+    Uninstall {
+        #[clap(help = "The version to install")]
+        version: Option<String>,
+    },
 
-  #[clap(about = "Use a given version or a semver range or a alias to the range.")]
-  #[clap(disable_version_flag = true)]
-  Use {
-    #[clap(help = "The version, semver range or alias to use")]
-    version: Option<String>,
+    #[clap(about = "Use a given version or a semver range or a alias to the range.")]
+    #[clap(disable_version_flag = true)]
+    Use {
+        #[clap(help = "The version, semver range or alias to use")]
+        version: Option<String>,
 
-    #[clap(
-      short,
-      long,
-      help = "Writing the version to the .dvmrc file of the current directory if present"
-    )]
-    local: bool,
-  },
+        #[clap(
+        short = 'L',
+        long = "write-local",
+        help = "Writing the version to the .dvmrc file of the current directory if present"
+        )]
+        write_local: bool,
+    },
 
-  #[clap(about = "Set or unset an alias")]
-  Alias {
-    #[clap(subcommand)]
-    command: AliasCommands,
-  },
+    #[clap(about = "Set or unset an alias")]
+    Alias {
+        #[clap(subcommand)]
+        command: AliasCommands,
+    },
 
-  #[clap(about = "Activate Dvm")]
-  Activate,
-  #[clap(about = "Deactivate Dvm")]
-  Deactivate,
+    #[clap(about = "Activate Dvm")]
+    Activate,
+    #[clap(about = "Deactivate Dvm")]
+    Deactivate,
 
-  #[clap(about = "Fixing dvm specific environment variables and other issues")]
-  Doctor,
+    #[clap(about = "Fixing dvm specific environment variables and other issues")]
+    Doctor,
 
-  #[clap(about = "Upgrade aliases to the latest version")]
-  Upgrade {
-    #[clap(help = "The alias to upgrade, upgrade all aliases if not present")]
-    alias: Option<String>,
-  },
+    #[clap(about = "Upgrade aliases to the latest version")]
+    Upgrade {
+        #[clap(help = "The alias to upgrade, upgrade all aliases if not present")]
+        alias: Option<String>,
+    },
 
-  #[clap(about = "Execute deno command with a specific deno version")]
-  #[clap(disable_version_flag = true)]
-  Exec {
-    #[clap(help = "The command given to deno")]
-    command: Option<String>,
+    #[clap(about = "Execute deno command with a specific deno version")]
+    #[clap(disable_version_flag = true)]
+    Exec {
+        #[clap(help = "The command given to deno")]
+        command: Option<String>,
 
-    #[clap(help = "The version to use", long, short)]
-    version: Option<String>,
-  },
+        #[clap(help = "The version to use", long, short)]
+        version: Option<String>,
+    },
 
-  #[clap(about = "Clean dvm cache")]
-  Clean,
+    #[clap(about = "Clean dvm cache")]
+    Clean,
 
-  #[clap(about = "Change registry that dvm fetch from")]
-  Registry {
-    #[clap(subcommand)]
-    command: RegistryCommands,
-  },
+    #[clap(about = "Change registry that dvm fetch from")]
+    Registry {
+        #[clap(subcommand)]
+        command: RegistryCommands,
+    },
 }
 
 #[derive(Subcommand)]
 pub enum AliasCommands {
-  #[clap(about = "Set an alias")]
-  Set {
-    #[clap(help = "Alias name to set")]
-    name: String,
-    #[clap(help = "Alias content")]
-    content: String,
-  },
+    #[clap(about = "Set an alias")]
+    Set {
+        #[clap(help = "Alias name to set")]
+        name: String,
+        #[clap(help = "Alias content")]
+        content: String,
+    },
 
-  #[clap(about = "Unset an alias")]
-  Unset {
-    #[clap(help = "Alias name to unset")]
-    name: String,
-  },
+    #[clap(about = "Unset an alias")]
+    Unset {
+        #[clap(help = "Alias name to unset")]
+        name: String,
+    },
 
-  #[clap(about = "List all aliases")]
-  List,
+    #[clap(about = "List all aliases")]
+    List,
 }
 
 #[derive(Subcommand)]
 pub enum RegistryCommands {
-  #[clap(about = "List predefined registries")]
-  List,
+    #[clap(about = "List predefined registries")]
+    List,
 
-  #[clap(about = "Show current binary registry and version registry")]
-  Show,
+    #[clap(about = "Show current binary registry and version registry")]
+    Show,
 
-  #[clap(about = "Set registry to one of predefined registries")]
-  Set { predefined: RegistryPredefined },
+    #[clap(about = "Set registry to one of predefined registries")]
+    Set {
+        predefined: RegistryPredefined,
 
-  #[clap(about = "Binary registry operations")]
-  Binary {
-    #[clap(subcommand)]
-    sub: BinaryRegistryCommands,
-  },
+        #[clap(long = "write-local", short = 'L', help = "Write to current directory .dvmrc file instead of global(user-wide) config")]
+        write_local: Option<bool>,
+    },
 
-  #[clap(about = "Version registry operations")]
-  Version {
-    #[clap(subcommand)]
-    sub: VersionRegistryCommands,
-  },
+    #[clap(about = "Binary registry operations")]
+    Binary {
+        #[clap(subcommand)]
+        sub: BinaryRegistryCommands,
+    },
+
+    #[clap(about = "Version registry operations")]
+    Version {
+        #[clap(subcommand)]
+        sub: VersionRegistryCommands,
+    },
 }
 
 #[derive(Subcommand)]
 pub enum BinaryRegistryCommands {
-  #[clap(about = "Show current binary registry")]
-  Show,
-  #[clap(about = "Set binary registry to one of predefined registries")]
-  Set { custom: String },
+    #[clap(about = "Show current binary registry")]
+    Show,
+    #[clap(about = "Set binary registry to one of predefined registries")]
+    Set {
+        custom: String,
+        #[clap(long = "write-local", short = 'L', help = "Write to current directory .dvmrc file instead of global(user-wide) config")]
+        write_local: bool,
+    },
 }
 
 #[derive(Subcommand)]
 pub enum VersionRegistryCommands {
-  #[clap(about = "Show current version registry")]
-  Show,
-  #[clap(about = "Set version registry to one of predefined registries")]
-  Set { custom: String },
+    #[clap(about = "Show current version registry")]
+    Show,
+    #[clap(about = "Set version registry to one of predefined registries")]
+    Set {
+        custom: String,
+        #[clap(long = "write-local", short = 'L', help = "Write to current directory .dvmrc file instead of global(user-wide) config")]
+        write_local: bool,
+    },
 }
 
 #[derive(Clone)]
 pub enum RegistryPredefined {
-  Official,
-  CN,
+    Official,
+    CN,
 }
 
 impl ValueEnum for RegistryPredefined {
-  fn value_variants<'a>() -> &'a [Self] {
-    &[RegistryPredefined::Official, RegistryPredefined::CN]
-  }
-
-  fn from_str(input: &str, ignore_case: bool) -> Result<Self, String> {
-    if (ignore_case && REGISTRY_NAME_OFFICIAL == input.to_ascii_lowercase()) || REGISTRY_NAME_OFFICIAL == input {
-      Ok(RegistryPredefined::Official)
-    } else if (ignore_case && REGISTRY_NAME_CN == input.to_ascii_lowercase()) || REGISTRY_NAME_CN == input {
-      Ok(RegistryPredefined::CN)
-    } else {
-      Err(format!("{} is not a valid registry", input))
+    fn value_variants<'a>() -> &'a [Self] {
+        &[RegistryPredefined::Official, RegistryPredefined::CN]
     }
-  }
 
-  fn to_possible_value(&self) -> Option<PossibleValue> {
-    Some(PossibleValue::new(match self {
-      RegistryPredefined::Official => REGISTRY_NAME_OFFICIAL,
-      RegistryPredefined::CN => REGISTRY_NAME_CN,
-    }))
-  }
+    fn from_str(input: &str, ignore_case: bool) -> Result<Self, String> {
+        if (ignore_case && REGISTRY_NAME_OFFICIAL == input.to_ascii_lowercase()) || REGISTRY_NAME_OFFICIAL == input {
+            Ok(RegistryPredefined::Official)
+        } else if (ignore_case && REGISTRY_NAME_CN == input.to_ascii_lowercase()) || REGISTRY_NAME_CN == input {
+            Ok(RegistryPredefined::CN)
+        } else {
+            Err(format!("{} is not a valid registry", input))
+        }
+    }
+
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        Some(PossibleValue::new(match self {
+            RegistryPredefined::Official => REGISTRY_NAME_OFFICIAL,
+            RegistryPredefined::CN => REGISTRY_NAME_CN,
+        }))
+    }
 }
 
 impl RegistryPredefined {
-  pub fn get_version_url(&self) -> String {
-    match self {
-      RegistryPredefined::Official => REGISTRY_LIST_OFFICIAL,
-      RegistryPredefined::CN => REGISTRY_LIST_CN,
+    pub fn get_version_url(&self) -> String {
+        match self {
+            RegistryPredefined::Official => REGISTRY_LIST_OFFICIAL,
+            RegistryPredefined::CN => REGISTRY_LIST_CN,
+        }
+            .to_string()
     }
-    .to_string()
-  }
 
-  pub fn get_binary_url(&self) -> String {
-    match self {
-      RegistryPredefined::Official => REGISTRY_OFFICIAL,
-      RegistryPredefined::CN => REGISTRY_CN,
+    pub fn get_binary_url(&self) -> String {
+        match self {
+            RegistryPredefined::Official => REGISTRY_OFFICIAL,
+            RegistryPredefined::CN => REGISTRY_CN,
+        }
+            .to_string()
     }
-    .to_string()
-  }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,45 +7,45 @@ use clap_derive::{Parser, Subcommand};
 
 use crate::commands;
 use crate::consts::{
-    AFTER_HELP, COMPLETIONS_HELP, REGISTRY_CN, REGISTRY_LIST_CN, REGISTRY_LIST_OFFICIAL, REGISTRY_NAME_CN,
-    REGISTRY_NAME_OFFICIAL, REGISTRY_OFFICIAL,
+  AFTER_HELP, COMPLETIONS_HELP, REGISTRY_CN, REGISTRY_LIST_CN, REGISTRY_LIST_OFFICIAL, REGISTRY_NAME_CN,
+  REGISTRY_NAME_OFFICIAL, REGISTRY_OFFICIAL,
 };
 use crate::meta::DvmMeta;
 
 pub fn cli_parse(meta: &mut DvmMeta) -> Result<Cli, ()> {
-    let args: Vec<String> = env::args().collect();
-    if args.len() > 1 && args[1] == "exec" {
-        if args.len() > 2 {
-            let version: Option<String>;
-            let exec_args: Vec<String>;
-            if args[2] == "--version" || args[2] == "-V" {
-                if args.len() > 3 {
-                    version = Some(args[3].clone());
-                    exec_args = args[4..].to_vec();
-                } else {
-                    eprintln!("A version should be followed after {}", args[2]);
-                    std::process::exit(1)
-                }
-            } else if args[2].starts_with("--version=") || args[2].starts_with("-V=") {
-                version = Some(
-                    args[2]
-                        .trim_start_matches("-V=")
-                        .trim_start_matches("--version=")
-                        .to_string(),
-                );
-                exec_args = args[3..].to_vec();
-            } else {
-                version = None;
-                exec_args = args[2..].to_vec();
-            }
-            commands::exec::exec(meta, version, exec_args).unwrap();
+  let args: Vec<String> = env::args().collect();
+  if args.len() > 1 && args[1] == "exec" {
+    if args.len() > 2 {
+      let version: Option<String>;
+      let exec_args: Vec<String>;
+      if args[2] == "--version" || args[2] == "-V" {
+        if args.len() > 3 {
+          version = Some(args[3].clone());
+          exec_args = args[4..].to_vec();
         } else {
-            commands::exec::exec(meta, None, vec![]).unwrap();
+          eprintln!("A version should be followed after {}", args[2]);
+          std::process::exit(1)
         }
-        return Err(());
+      } else if args[2].starts_with("--version=") || args[2].starts_with("-V=") {
+        version = Some(
+          args[2]
+            .trim_start_matches("-V=")
+            .trim_start_matches("--version=")
+            .to_string(),
+        );
+        exec_args = args[3..].to_vec();
+      } else {
+        version = None;
+        exec_args = args[2..].to_vec();
+      }
+      commands::exec::exec(meta, version, exec_args).unwrap();
+    } else {
+      commands::exec::exec(meta, None, vec![]).unwrap();
     }
+    return Err(());
+  }
 
-    Ok(Cli::parse())
+  Ok(Cli::parse())
 }
 
 #[derive(Parser)]
@@ -53,216 +53,228 @@ pub fn cli_parse(meta: &mut DvmMeta) -> Result<Cli, ()> {
 #[clap(after_help = AFTER_HELP)]
 #[clap(propagate_version = true)]
 pub struct Cli {
-    #[clap(subcommand)]
-    pub command: Commands,
+  #[clap(subcommand)]
+  pub command: Commands,
 }
 
 #[derive(Subcommand)]
 pub enum Commands {
-    #[clap(about = "Generate shell completions")]
-    #[clap(long_about = COMPLETIONS_HELP)]
-    Completions {
-        #[arg(value_enum)]
-        shell: Shell,
-    },
+  #[clap(about = "Generate shell completions")]
+  #[clap(long_about = COMPLETIONS_HELP)]
+  Completions {
+    #[arg(value_enum)]
+    shell: Shell,
+  },
 
-    #[clap(about = "Show dvm info.")]
-    Info,
+  #[clap(about = "Show dvm info.")]
+  Info,
 
-    #[clap(about = "Install deno executable to the given version.")]
-    #[clap(visible_aliases = & ["i", "add"])]
-    Install {
-        #[clap(long, help = "Only install to local, but not use")]
-        no_use: bool,
-        #[clap(help = "The version to install")]
-        version: Option<String>,
-    },
+  #[clap(about = "Install deno executable to the given version.")]
+  #[clap(visible_aliases = & ["i", "add"])]
+  Install {
+    #[clap(long, help = "Only install to local, but not use")]
+    no_use: bool,
+    #[clap(help = "The version to install")]
+    version: Option<String>,
+  },
 
-    #[clap(about = "List all installed versions")]
-    #[clap(visible_aliases = & ["ls", "ll", "la"])]
-    List,
+  #[clap(about = "List all installed versions")]
+  #[clap(visible_aliases = & ["ls", "ll", "la"])]
+  List,
 
-    #[clap(about = "List all released versions")]
-    #[clap(visible_aliases = & ["lr", "ls-remote"])]
-    ListRemote,
+  #[clap(about = "List all released versions")]
+  #[clap(visible_aliases = & ["lr", "ls-remote"])]
+  ListRemote,
 
-    #[clap(about = "Uninstall a given version")]
-    #[clap(visible_aliases = & ["un", "unlink", "rm", "remove"])]
-    Uninstall {
-        #[clap(help = "The version to install")]
-        version: Option<String>,
-    },
+  #[clap(about = "Uninstall a given version")]
+  #[clap(visible_aliases = & ["un", "unlink", "rm", "remove"])]
+  Uninstall {
+    #[clap(help = "The version to install")]
+    version: Option<String>,
+  },
 
-    #[clap(about = "Use a given version or a semver range or a alias to the range.")]
-    #[clap(disable_version_flag = true)]
-    Use {
-        #[clap(help = "The version, semver range or alias to use")]
-        version: Option<String>,
+  #[clap(about = "Use a given version or a semver range or a alias to the range.")]
+  #[clap(disable_version_flag = true)]
+  Use {
+    #[clap(help = "The version, semver range or alias to use")]
+    version: Option<String>,
 
-        #[clap(
-        short = 'L',
-        long = "write-local",
-        help = "Writing the version to the .dvmrc file of the current directory if present"
-        )]
-        write_local: bool,
-    },
+    #[clap(
+      short = 'L',
+      long = "write-local",
+      help = "Writing the version to the .dvmrc file of the current directory if present"
+    )]
+    write_local: bool,
+  },
 
-    #[clap(about = "Set or unset an alias")]
-    Alias {
-        #[clap(subcommand)]
-        command: AliasCommands,
-    },
+  #[clap(about = "Set or unset an alias")]
+  Alias {
+    #[clap(subcommand)]
+    command: AliasCommands,
+  },
 
-    #[clap(about = "Activate Dvm")]
-    Activate,
-    #[clap(about = "Deactivate Dvm")]
-    Deactivate,
+  #[clap(about = "Activate Dvm")]
+  Activate,
+  #[clap(about = "Deactivate Dvm")]
+  Deactivate,
 
-    #[clap(about = "Fixing dvm specific environment variables and other issues")]
-    Doctor,
+  #[clap(about = "Fixing dvm specific environment variables and other issues")]
+  Doctor,
 
-    #[clap(about = "Upgrade aliases to the latest version")]
-    Upgrade {
-        #[clap(help = "The alias to upgrade, upgrade all aliases if not present")]
-        alias: Option<String>,
-    },
+  #[clap(about = "Upgrade aliases to the latest version")]
+  Upgrade {
+    #[clap(help = "The alias to upgrade, upgrade all aliases if not present")]
+    alias: Option<String>,
+  },
 
-    #[clap(about = "Execute deno command with a specific deno version")]
-    #[clap(disable_version_flag = true)]
-    Exec {
-        #[clap(help = "The command given to deno")]
-        command: Option<String>,
+  #[clap(about = "Execute deno command with a specific deno version")]
+  #[clap(disable_version_flag = true)]
+  Exec {
+    #[clap(help = "The command given to deno")]
+    command: Option<String>,
 
-        #[clap(help = "The version to use", long, short)]
-        version: Option<String>,
-    },
+    #[clap(help = "The version to use", long, short)]
+    version: Option<String>,
+  },
 
-    #[clap(about = "Clean dvm cache")]
-    Clean,
+  #[clap(about = "Clean dvm cache")]
+  Clean,
 
-    #[clap(about = "Change registry that dvm fetch from")]
-    Registry {
-        #[clap(subcommand)]
-        command: RegistryCommands,
-    },
+  #[clap(about = "Change registry that dvm fetch from")]
+  Registry {
+    #[clap(subcommand)]
+    command: RegistryCommands,
+  },
 }
 
 #[derive(Subcommand)]
 pub enum AliasCommands {
-    #[clap(about = "Set an alias")]
-    Set {
-        #[clap(help = "Alias name to set")]
-        name: String,
-        #[clap(help = "Alias content")]
-        content: String,
-    },
+  #[clap(about = "Set an alias")]
+  Set {
+    #[clap(help = "Alias name to set")]
+    name: String,
+    #[clap(help = "Alias content")]
+    content: String,
+  },
 
-    #[clap(about = "Unset an alias")]
-    Unset {
-        #[clap(help = "Alias name to unset")]
-        name: String,
-    },
+  #[clap(about = "Unset an alias")]
+  Unset {
+    #[clap(help = "Alias name to unset")]
+    name: String,
+  },
 
-    #[clap(about = "List all aliases")]
-    List,
+  #[clap(about = "List all aliases")]
+  List,
 }
 
 #[derive(Subcommand)]
 pub enum RegistryCommands {
-    #[clap(about = "List predefined registries")]
-    List,
+  #[clap(about = "List predefined registries")]
+  List,
 
-    #[clap(about = "Show current binary registry and version registry")]
-    Show,
+  #[clap(about = "Show current binary registry and version registry")]
+  Show,
 
-    #[clap(about = "Set registry to one of predefined registries")]
-    Set {
-        predefined: RegistryPredefined,
+  #[clap(about = "Set registry to one of predefined registries")]
+  Set {
+    predefined: RegistryPredefined,
 
-        #[clap(long = "write-local", short = 'L', help = "Write to current directory .dvmrc file instead of global(user-wide) config")]
-        write_local: Option<bool>,
-    },
+    #[clap(
+      long = "write-local",
+      short = 'L',
+      help = "Write to current directory .dvmrc file instead of global(user-wide) config"
+    )]
+    write_local: bool,
+  },
 
-    #[clap(about = "Binary registry operations")]
-    Binary {
-        #[clap(subcommand)]
-        sub: BinaryRegistryCommands,
-    },
+  #[clap(about = "Binary registry operations")]
+  Binary {
+    #[clap(subcommand)]
+    sub: BinaryRegistryCommands,
+  },
 
-    #[clap(about = "Version registry operations")]
-    Version {
-        #[clap(subcommand)]
-        sub: VersionRegistryCommands,
-    },
+  #[clap(about = "Version registry operations")]
+  Version {
+    #[clap(subcommand)]
+    sub: VersionRegistryCommands,
+  },
 }
 
 #[derive(Subcommand)]
 pub enum BinaryRegistryCommands {
-    #[clap(about = "Show current binary registry")]
-    Show,
-    #[clap(about = "Set binary registry to one of predefined registries")]
-    Set {
-        custom: String,
-        #[clap(long = "write-local", short = 'L', help = "Write to current directory .dvmrc file instead of global(user-wide) config")]
-        write_local: bool,
-    },
+  #[clap(about = "Show current binary registry")]
+  Show,
+  #[clap(about = "Set binary registry to one of predefined registries")]
+  Set {
+    custom: String,
+    #[clap(
+      long = "write-local",
+      short = 'L',
+      help = "Write to current directory .dvmrc file instead of global(user-wide) config"
+    )]
+    write_local: bool,
+  },
 }
 
 #[derive(Subcommand)]
 pub enum VersionRegistryCommands {
-    #[clap(about = "Show current version registry")]
-    Show,
-    #[clap(about = "Set version registry to one of predefined registries")]
-    Set {
-        custom: String,
-        #[clap(long = "write-local", short = 'L', help = "Write to current directory .dvmrc file instead of global(user-wide) config")]
-        write_local: bool,
-    },
+  #[clap(about = "Show current version registry")]
+  Show,
+  #[clap(about = "Set version registry to one of predefined registries")]
+  Set {
+    custom: String,
+    #[clap(
+      long = "write-local",
+      short = 'L',
+      help = "Write to current directory .dvmrc file instead of global(user-wide) config"
+    )]
+    write_local: bool,
+  },
 }
 
 #[derive(Clone)]
 pub enum RegistryPredefined {
-    Official,
-    CN,
+  Official,
+  CN,
 }
 
 impl ValueEnum for RegistryPredefined {
-    fn value_variants<'a>() -> &'a [Self] {
-        &[RegistryPredefined::Official, RegistryPredefined::CN]
-    }
+  fn value_variants<'a>() -> &'a [Self] {
+    &[RegistryPredefined::Official, RegistryPredefined::CN]
+  }
 
-    fn from_str(input: &str, ignore_case: bool) -> Result<Self, String> {
-        if (ignore_case && REGISTRY_NAME_OFFICIAL == input.to_ascii_lowercase()) || REGISTRY_NAME_OFFICIAL == input {
-            Ok(RegistryPredefined::Official)
-        } else if (ignore_case && REGISTRY_NAME_CN == input.to_ascii_lowercase()) || REGISTRY_NAME_CN == input {
-            Ok(RegistryPredefined::CN)
-        } else {
-            Err(format!("{} is not a valid registry", input))
-        }
+  fn from_str(input: &str, ignore_case: bool) -> Result<Self, String> {
+    if (ignore_case && REGISTRY_NAME_OFFICIAL == input.to_ascii_lowercase()) || REGISTRY_NAME_OFFICIAL == input {
+      Ok(RegistryPredefined::Official)
+    } else if (ignore_case && REGISTRY_NAME_CN == input.to_ascii_lowercase()) || REGISTRY_NAME_CN == input {
+      Ok(RegistryPredefined::CN)
+    } else {
+      Err(format!("{} is not a valid registry", input))
     }
+  }
 
-    fn to_possible_value(&self) -> Option<PossibleValue> {
-        Some(PossibleValue::new(match self {
-            RegistryPredefined::Official => REGISTRY_NAME_OFFICIAL,
-            RegistryPredefined::CN => REGISTRY_NAME_CN,
-        }))
-    }
+  fn to_possible_value(&self) -> Option<PossibleValue> {
+    Some(PossibleValue::new(match self {
+      RegistryPredefined::Official => REGISTRY_NAME_OFFICIAL,
+      RegistryPredefined::CN => REGISTRY_NAME_CN,
+    }))
+  }
 }
 
 impl RegistryPredefined {
-    pub fn get_version_url(&self) -> String {
-        match self {
-            RegistryPredefined::Official => REGISTRY_LIST_OFFICIAL,
-            RegistryPredefined::CN => REGISTRY_LIST_CN,
-        }
-            .to_string()
+  pub fn get_version_url(&self) -> String {
+    match self {
+      RegistryPredefined::Official => REGISTRY_LIST_OFFICIAL,
+      RegistryPredefined::CN => REGISTRY_LIST_CN,
     }
+    .to_string()
+  }
 
-    pub fn get_binary_url(&self) -> String {
-        match self {
-            RegistryPredefined::Official => REGISTRY_OFFICIAL,
-            RegistryPredefined::CN => REGISTRY_CN,
-        }
-            .to_string()
+  pub fn get_binary_url(&self) -> String {
+    match self {
+      RegistryPredefined::Official => REGISTRY_OFFICIAL,
+      RegistryPredefined::CN => REGISTRY_CN,
     }
+    .to_string()
+  }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,43 +6,46 @@ use clap_complete::Shell;
 use clap_derive::{Parser, Subcommand};
 
 use crate::commands;
-use crate::consts::{AFTER_HELP, COMPLETIONS_HELP, REGISTRY_CN, REGISTRY_LIST_CN, REGISTRY_LIST_OFFICIAL, REGISTRY_NAME_CN, REGISTRY_NAME_OFFICIAL, REGISTRY_OFFICIAL};
+use crate::consts::{
+  AFTER_HELP, COMPLETIONS_HELP, REGISTRY_CN, REGISTRY_LIST_CN, REGISTRY_LIST_OFFICIAL, REGISTRY_NAME_CN,
+  REGISTRY_NAME_OFFICIAL, REGISTRY_OFFICIAL,
+};
 use crate::meta::DvmMeta;
 
 pub fn cli_parse(meta: &mut DvmMeta) -> Result<Cli, ()> {
-    let args: Vec<String> = env::args().collect();
-    if args.len() > 1 && args[1] == "exec" {
-        if args.len() > 2 {
-            let version: Option<String>;
-            let exec_args: Vec<String>;
-            if args[2] == "--version" || args[2] == "-V" {
-                if args.len() > 3 {
-                    version = Some(args[3].clone());
-                    exec_args = args[4..].to_vec();
-                } else {
-                    eprintln!("A version should be followed after {}", args[2]);
-                    std::process::exit(1)
-                }
-            } else if args[2].starts_with("--version=") || args[2].starts_with("-V=") {
-                version = Some(
-                    args[2]
-                        .trim_start_matches("-V=")
-                        .trim_start_matches("--version=")
-                        .to_string(),
-                );
-                exec_args = args[3..].to_vec();
-            } else {
-                version = None;
-                exec_args = args[2..].to_vec();
-            }
-            commands::exec::exec(meta, version, exec_args).unwrap();
+  let args: Vec<String> = env::args().collect();
+  if args.len() > 1 && args[1] == "exec" {
+    if args.len() > 2 {
+      let version: Option<String>;
+      let exec_args: Vec<String>;
+      if args[2] == "--version" || args[2] == "-V" {
+        if args.len() > 3 {
+          version = Some(args[3].clone());
+          exec_args = args[4..].to_vec();
         } else {
-            commands::exec::exec(meta, None, vec![]).unwrap();
+          eprintln!("A version should be followed after {}", args[2]);
+          std::process::exit(1)
         }
-        return Err(());
+      } else if args[2].starts_with("--version=") || args[2].starts_with("-V=") {
+        version = Some(
+          args[2]
+            .trim_start_matches("-V=")
+            .trim_start_matches("--version=")
+            .to_string(),
+        );
+        exec_args = args[3..].to_vec();
+      } else {
+        version = None;
+        exec_args = args[2..].to_vec();
+      }
+      commands::exec::exec(meta, version, exec_args).unwrap();
+    } else {
+      commands::exec::exec(meta, None, vec![]).unwrap();
     }
+    return Err(());
+  }
 
-    Ok(Cli::parse())
+  Ok(Cli::parse())
 }
 
 #[derive(Parser)]
@@ -50,203 +53,203 @@ pub fn cli_parse(meta: &mut DvmMeta) -> Result<Cli, ()> {
 #[clap(after_help = AFTER_HELP)]
 #[clap(propagate_version = true)]
 pub struct Cli {
-    #[clap(subcommand)]
-    pub command: Commands,
+  #[clap(subcommand)]
+  pub command: Commands,
 }
 
 #[derive(Subcommand)]
 pub enum Commands {
-    #[clap(about = "Generate shell completions")]
-    #[clap(long_about = COMPLETIONS_HELP)]
-    Completions {
-        #[arg(value_enum)]
-        shell: Shell,
-    },
+  #[clap(about = "Generate shell completions")]
+  #[clap(long_about = COMPLETIONS_HELP)]
+  Completions {
+    #[arg(value_enum)]
+    shell: Shell,
+  },
 
-    #[clap(about = "Show dvm info.")]
-    Info,
+  #[clap(about = "Show dvm info.")]
+  Info,
 
-    #[clap(about = "Install deno executable to the given version.")]
-    #[clap(visible_aliases = & ["i", "add"])]
-    Install {
-        #[clap(long, help = "Only install to local, but not use")]
-        no_use: bool,
-        #[clap(help = "The version to install")]
-        version: Option<String>,
-    },
+  #[clap(about = "Install deno executable to the given version.")]
+  #[clap(visible_aliases = & ["i", "add"])]
+  Install {
+    #[clap(long, help = "Only install to local, but not use")]
+    no_use: bool,
+    #[clap(help = "The version to install")]
+    version: Option<String>,
+  },
 
-    #[clap(about = "List all installed versions")]
-    #[clap(visible_aliases = & ["ls", "ll", "la"])]
-    List,
+  #[clap(about = "List all installed versions")]
+  #[clap(visible_aliases = & ["ls", "ll", "la"])]
+  List,
 
-    #[clap(about = "List all released versions")]
-    #[clap(visible_aliases = & ["lr", "ls-remote"])]
-    ListRemote,
+  #[clap(about = "List all released versions")]
+  #[clap(visible_aliases = & ["lr", "ls-remote"])]
+  ListRemote,
 
-    #[clap(about = "Uninstall a given version")]
-    #[clap(visible_aliases = & ["un", "unlink", "rm", "remove"])]
-    Uninstall {
-        #[clap(help = "The version to install")]
-        version: Option<String>,
-    },
+  #[clap(about = "Uninstall a given version")]
+  #[clap(visible_aliases = & ["un", "unlink", "rm", "remove"])]
+  Uninstall {
+    #[clap(help = "The version to install")]
+    version: Option<String>,
+  },
 
-    #[clap(about = "Use a given version or a semver range or a alias to the range.")]
-    #[clap(disable_version_flag = true)]
-    Use {
-        #[clap(help = "The version, semver range or alias to use")]
-        version: Option<String>,
+  #[clap(about = "Use a given version or a semver range or a alias to the range.")]
+  #[clap(disable_version_flag = true)]
+  Use {
+    #[clap(help = "The version, semver range or alias to use")]
+    version: Option<String>,
 
-        #[clap(
-        short,
-        long,
-        help = "Writing the version to the .dvmrc file of the current directory if present"
-        )]
-        local: bool,
-    },
+    #[clap(
+      short,
+      long,
+      help = "Writing the version to the .dvmrc file of the current directory if present"
+    )]
+    local: bool,
+  },
 
-    #[clap(about = "Set or unset an alias")]
-    Alias {
-        #[clap(subcommand)]
-        command: AliasCommands,
-    },
+  #[clap(about = "Set or unset an alias")]
+  Alias {
+    #[clap(subcommand)]
+    command: AliasCommands,
+  },
 
-    #[clap(about = "Activate Dvm")]
-    Activate,
-    #[clap(about = "Deactivate Dvm")]
-    Deactivate,
+  #[clap(about = "Activate Dvm")]
+  Activate,
+  #[clap(about = "Deactivate Dvm")]
+  Deactivate,
 
-    #[clap(about = "Fixing dvm specific environment variables and other issues")]
-    Doctor,
+  #[clap(about = "Fixing dvm specific environment variables and other issues")]
+  Doctor,
 
-    #[clap(about = "Upgrade aliases to the latest version")]
-    Upgrade {
-        #[clap(help = "The alias to upgrade, upgrade all aliases if not present")]
-        alias: Option<String>,
-    },
+  #[clap(about = "Upgrade aliases to the latest version")]
+  Upgrade {
+    #[clap(help = "The alias to upgrade, upgrade all aliases if not present")]
+    alias: Option<String>,
+  },
 
-    #[clap(about = "Execute deno command with a specific deno version")]
-    #[clap(disable_version_flag = true)]
-    Exec {
-        #[clap(help = "The command given to deno")]
-        command: Option<String>,
+  #[clap(about = "Execute deno command with a specific deno version")]
+  #[clap(disable_version_flag = true)]
+  Exec {
+    #[clap(help = "The command given to deno")]
+    command: Option<String>,
 
-        #[clap(help = "The version to use", long, short)]
-        version: Option<String>,
-    },
+    #[clap(help = "The version to use", long, short)]
+    version: Option<String>,
+  },
 
-    #[clap(about = "Clean dvm cache")]
-    Clean,
+  #[clap(about = "Clean dvm cache")]
+  Clean,
 
-    #[clap(about = "Change registry that dvm fetch from")]
-    Registry {
-        #[clap(subcommand)]
-        command: RegistryCommands,
-    },
+  #[clap(about = "Change registry that dvm fetch from")]
+  Registry {
+    #[clap(subcommand)]
+    command: RegistryCommands,
+  },
 }
 
 #[derive(Subcommand)]
 pub enum AliasCommands {
-    #[clap(about = "Set an alias")]
-    Set {
-        #[clap(help = "Alias name to set")]
-        name: String,
-        #[clap(help = "Alias content")]
-        content: String,
-    },
+  #[clap(about = "Set an alias")]
+  Set {
+    #[clap(help = "Alias name to set")]
+    name: String,
+    #[clap(help = "Alias content")]
+    content: String,
+  },
 
-    #[clap(about = "Unset an alias")]
-    Unset {
-        #[clap(help = "Alias name to unset")]
-        name: String,
-    },
+  #[clap(about = "Unset an alias")]
+  Unset {
+    #[clap(help = "Alias name to unset")]
+    name: String,
+  },
 
-    #[clap(about = "List all aliases")]
-    List,
+  #[clap(about = "List all aliases")]
+  List,
 }
 
 #[derive(Subcommand)]
 pub enum RegistryCommands {
-    #[clap(about = "List predefined registries")]
-    List,
+  #[clap(about = "List predefined registries")]
+  List,
 
-    #[clap(about = "Show current binary registry and version registry")]
-    Show,
+  #[clap(about = "Show current binary registry and version registry")]
+  Show,
 
-    #[clap(about = "Set registry to one of predefined registries")]
-    Set { predefined: RegistryPredefined },
+  #[clap(about = "Set registry to one of predefined registries")]
+  Set { predefined: RegistryPredefined },
 
-    #[clap(about = "Binary registry operations")]
-    Binary {
-        #[clap(subcommand)]
-        sub: BinaryRegistryCommands,
-    },
+  #[clap(about = "Binary registry operations")]
+  Binary {
+    #[clap(subcommand)]
+    sub: BinaryRegistryCommands,
+  },
 
-    #[clap(about = "Version registry operations")]
-    Version {
-        #[clap(subcommand)]
-        sub: VersionRegistryCommands,
-    },
+  #[clap(about = "Version registry operations")]
+  Version {
+    #[clap(subcommand)]
+    sub: VersionRegistryCommands,
+  },
 }
 
 #[derive(Subcommand)]
 pub enum BinaryRegistryCommands {
-    #[clap(about = "Show current binary registry")]
-    Show,
-    #[clap(about = "Set binary registry to one of predefined registries")]
-    Set { custom: String },
+  #[clap(about = "Show current binary registry")]
+  Show,
+  #[clap(about = "Set binary registry to one of predefined registries")]
+  Set { custom: String },
 }
 
 #[derive(Subcommand)]
 pub enum VersionRegistryCommands {
-    #[clap(about = "Show current version registry")]
-    Show,
-    #[clap(about = "Set version registry to one of predefined registries")]
-    Set { custom: String },
+  #[clap(about = "Show current version registry")]
+  Show,
+  #[clap(about = "Set version registry to one of predefined registries")]
+  Set { custom: String },
 }
 
 #[derive(Clone)]
 pub enum RegistryPredefined {
-    Official,
-    CN,
+  Official,
+  CN,
 }
 
 impl ValueEnum for RegistryPredefined {
-    fn value_variants<'a>() -> &'a [Self] {
-        &[RegistryPredefined::Official, RegistryPredefined::CN]
-    }
+  fn value_variants<'a>() -> &'a [Self] {
+    &[RegistryPredefined::Official, RegistryPredefined::CN]
+  }
 
-    fn from_str(input: &str, ignore_case: bool) -> Result<Self, String> {
-        if (ignore_case && REGISTRY_NAME_OFFICIAL == input.to_ascii_lowercase()) || REGISTRY_NAME_OFFICIAL == input {
-            Ok(RegistryPredefined::Official)
-        } else if (ignore_case && REGISTRY_NAME_CN == input.to_ascii_lowercase()) || REGISTRY_NAME_CN == input {
-            Ok(RegistryPredefined::CN)
-        } else {
-            Err(format!("{} is not a valid registry", input))
-        }
+  fn from_str(input: &str, ignore_case: bool) -> Result<Self, String> {
+    if (ignore_case && REGISTRY_NAME_OFFICIAL == input.to_ascii_lowercase()) || REGISTRY_NAME_OFFICIAL == input {
+      Ok(RegistryPredefined::Official)
+    } else if (ignore_case && REGISTRY_NAME_CN == input.to_ascii_lowercase()) || REGISTRY_NAME_CN == input {
+      Ok(RegistryPredefined::CN)
+    } else {
+      Err(format!("{} is not a valid registry", input))
     }
+  }
 
-    fn to_possible_value(&self) -> Option<PossibleValue> {
-        Some(PossibleValue::new(match self {
-            RegistryPredefined::Official => REGISTRY_NAME_OFFICIAL,
-            RegistryPredefined::CN => REGISTRY_NAME_CN,
-        }))
-    }
+  fn to_possible_value(&self) -> Option<PossibleValue> {
+    Some(PossibleValue::new(match self {
+      RegistryPredefined::Official => REGISTRY_NAME_OFFICIAL,
+      RegistryPredefined::CN => REGISTRY_NAME_CN,
+    }))
+  }
 }
 
 impl RegistryPredefined {
-    pub fn get_version_url(&self) -> String {
-        match self {
-            RegistryPredefined::Official => REGISTRY_LIST_OFFICIAL,
-            RegistryPredefined::CN => REGISTRY_LIST_CN,
-        }
-            .to_string()
+  pub fn get_version_url(&self) -> String {
+    match self {
+      RegistryPredefined::Official => REGISTRY_LIST_OFFICIAL,
+      RegistryPredefined::CN => REGISTRY_LIST_CN,
     }
+    .to_string()
+  }
 
-    pub fn get_binary_url(&self) -> String {
-        match self {
-            RegistryPredefined::Official => REGISTRY_OFFICIAL,
-            RegistryPredefined::CN => REGISTRY_CN,
-        }
-            .to_string()
+  pub fn get_binary_url(&self) -> String {
+    match self {
+      RegistryPredefined::Official => REGISTRY_OFFICIAL,
+      RegistryPredefined::CN => REGISTRY_CN,
     }
+    .to_string()
+  }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,47 +1,48 @@
 use std::env;
 
-use clap::Parser;
+use clap::builder::PossibleValue;
+use clap::{Parser, ValueEnum};
 use clap_complete::Shell;
 use clap_derive::{Parser, Subcommand};
 
 use crate::commands;
-use crate::consts::{AFTER_HELP, COMPLETIONS_HELP};
+use crate::consts::{AFTER_HELP, COMPLETIONS_HELP, REGISTRY_CN, REGISTRY_LIST_CN, REGISTRY_LIST_OFFICIAL, REGISTRY_NAME_CN, REGISTRY_NAME_OFFICIAL, REGISTRY_OFFICIAL};
 use crate::meta::DvmMeta;
 
 pub fn cli_parse(meta: &mut DvmMeta) -> Result<Cli, ()> {
-  let args: Vec<String> = env::args().collect();
-  if args.len() > 1 && args[1] == "exec" {
-    if args.len() > 2 {
-      let version: Option<String>;
-      let exec_args: Vec<String>;
-      if args[2] == "--version" || args[2] == "-V" {
-        if args.len() > 3 {
-          version = Some(args[3].clone());
-          exec_args = args[4..].to_vec();
+    let args: Vec<String> = env::args().collect();
+    if args.len() > 1 && args[1] == "exec" {
+        if args.len() > 2 {
+            let version: Option<String>;
+            let exec_args: Vec<String>;
+            if args[2] == "--version" || args[2] == "-V" {
+                if args.len() > 3 {
+                    version = Some(args[3].clone());
+                    exec_args = args[4..].to_vec();
+                } else {
+                    eprintln!("A version should be followed after {}", args[2]);
+                    std::process::exit(1)
+                }
+            } else if args[2].starts_with("--version=") || args[2].starts_with("-V=") {
+                version = Some(
+                    args[2]
+                        .trim_start_matches("-V=")
+                        .trim_start_matches("--version=")
+                        .to_string(),
+                );
+                exec_args = args[3..].to_vec();
+            } else {
+                version = None;
+                exec_args = args[2..].to_vec();
+            }
+            commands::exec::exec(meta, version, exec_args).unwrap();
         } else {
-          eprintln!("A version should be followed after {}", args[2]);
-          std::process::exit(1)
+            commands::exec::exec(meta, None, vec![]).unwrap();
         }
-      } else if args[2].starts_with("--version=") || args[2].starts_with("-V=") {
-        version = Some(
-          args[2]
-            .trim_start_matches("-V=")
-            .trim_start_matches("--version=")
-            .to_string(),
-        );
-        exec_args = args[3..].to_vec();
-      } else {
-        version = None;
-        exec_args = args[2..].to_vec();
-      }
-      commands::exec::exec(meta, version, exec_args).unwrap();
-    } else {
-      // TODO(CGQAQ): print help
+        return Err(());
     }
-    return Err(());
-  }
 
-  Ok(Cli::parse())
+    Ok(Cli::parse())
 }
 
 #[derive(Parser)]
@@ -49,114 +50,203 @@ pub fn cli_parse(meta: &mut DvmMeta) -> Result<Cli, ()> {
 #[clap(after_help = AFTER_HELP)]
 #[clap(propagate_version = true)]
 pub struct Cli {
-  #[clap(subcommand)]
-  pub command: Commands,
+    #[clap(subcommand)]
+    pub command: Commands,
 }
 
 #[derive(Subcommand)]
 pub enum Commands {
-  #[clap(about = "Generate shell completions")]
-  #[clap(long_about=COMPLETIONS_HELP)]
-  Completions {
-    #[arg(value_enum)]
-    shell: Shell,
-  },
+    #[clap(about = "Generate shell completions")]
+    #[clap(long_about = COMPLETIONS_HELP)]
+    Completions {
+        #[arg(value_enum)]
+        shell: Shell,
+    },
 
-  #[clap(about = "Show dvm info.")]
-  Info,
+    #[clap(about = "Show dvm info.")]
+    Info,
 
-  #[clap(about = "Install deno executable to the given version.")]
-  #[clap(visible_aliases=&["i", "add"])]
-  Install {
-    #[clap(long, help = "Only install to local, but not use")]
-    no_use: bool,
-    #[clap(help = "The version to install")]
-    version: Option<String>,
-  },
+    #[clap(about = "Install deno executable to the given version.")]
+    #[clap(visible_aliases = & ["i", "add"])]
+    Install {
+        #[clap(long, help = "Only install to local, but not use")]
+        no_use: bool,
+        #[clap(help = "The version to install")]
+        version: Option<String>,
+    },
 
-  #[clap(about = "List all installed versions")]
-  #[clap(visible_aliases=&["ls", "ll", "la"])]
-  List,
+    #[clap(about = "List all installed versions")]
+    #[clap(visible_aliases = & ["ls", "ll", "la"])]
+    List,
 
-  #[clap(about = "List all released versions")]
-  #[clap(visible_aliases=&["lr", "ls-remote"])]
-  ListRemote,
+    #[clap(about = "List all released versions")]
+    #[clap(visible_aliases = & ["lr", "ls-remote"])]
+    ListRemote,
 
-  #[clap(about = "Uninstall a given version")]
-  #[clap(visible_aliases=&["un", "unlink", "rm", "remove"])]
-  Uninstall {
-    #[clap(help = "The version to install")]
-    version: Option<String>,
-  },
+    #[clap(about = "Uninstall a given version")]
+    #[clap(visible_aliases = & ["un", "unlink", "rm", "remove"])]
+    Uninstall {
+        #[clap(help = "The version to install")]
+        version: Option<String>,
+    },
 
-  #[clap(about = "Use a given version or a semver range or a alias to the range.")]
-  Use {
-    #[clap(help = "The version, semver range or alias to use")]
-    version: Option<String>,
+    #[clap(about = "Use a given version or a semver range or a alias to the range.")]
+    #[clap(disable_version_flag = true)]
+    Use {
+        #[clap(help = "The version, semver range or alias to use")]
+        version: Option<String>,
 
-    #[clap(
-      short,
-      long,
-      help = "Writing the version to the .dvmrc file of the current directory if present"
-    )]
-    local: bool,
-  },
+        #[clap(
+        short,
+        long,
+        help = "Writing the version to the .dvmrc file of the current directory if present"
+        )]
+        local: bool,
+    },
 
-  #[clap(about = "Set or unset an alias")]
-  Alias {
-    #[clap(subcommand)]
-    command: AliasCommands,
-  },
+    #[clap(about = "Set or unset an alias")]
+    Alias {
+        #[clap(subcommand)]
+        command: AliasCommands,
+    },
 
-  #[clap(about = "Activate Dvm")]
-  Activate,
-  #[clap(about = "Deactivate Dvm")]
-  Deactivate,
+    #[clap(about = "Activate Dvm")]
+    Activate,
+    #[clap(about = "Deactivate Dvm")]
+    Deactivate,
 
-  #[clap(about = "Fixing dvm specific environment variables and other issues")]
-  Doctor,
+    #[clap(about = "Fixing dvm specific environment variables and other issues")]
+    Doctor,
 
-  #[clap(about = "Upgrade aliases to the latest version")]
-  Upgrade {
-    #[clap(help = "The alias to upgrade, upgrade all aliases if not present")]
-    alias: Option<String>,
-  },
+    #[clap(about = "Upgrade aliases to the latest version")]
+    Upgrade {
+        #[clap(help = "The alias to upgrade, upgrade all aliases if not present")]
+        alias: Option<String>,
+    },
 
-  #[clap(about = "Execute deno command with a specific deno version")]
-  Exec {
-    #[clap(help = "The command given to deno")]
-    command: Option<String>,
+    #[clap(about = "Execute deno command with a specific deno version")]
+    #[clap(disable_version_flag = true)]
+    Exec {
+        #[clap(help = "The command given to deno")]
+        command: Option<String>,
 
-    #[clap(help = "The version to use", long, short)]
-    deno_version: Option<String>,
-  },
+        #[clap(help = "The version to use", long, short)]
+        version: Option<String>,
+    },
 
-  #[clap(about = "Clean dvm cache")]
-  Clean,
+    #[clap(about = "Clean dvm cache")]
+    Clean,
 
-  #[clap(about = "Change registry that dvm fetch from")]
-  Registry {
-    #[clap(help = "The registry to be set, `official`, `cn`, or url you desired")]
-    registry: Option<String>,
-  },
+    #[clap(about = "Change registry that dvm fetch from")]
+    Registry {
+        #[clap(subcommand)]
+        command: RegistryCommands,
+    },
 }
 
 #[derive(Subcommand)]
 pub enum AliasCommands {
-  #[clap(about = "Set an alias")]
-  Set {
-    #[clap(help = "Alias name to set")]
-    name: String,
-    #[clap(help = "Alias content")]
-    content: String,
-  },
+    #[clap(about = "Set an alias")]
+    Set {
+        #[clap(help = "Alias name to set")]
+        name: String,
+        #[clap(help = "Alias content")]
+        content: String,
+    },
 
-  #[clap(about = "Unset an alias")]
-  Unset {
-    #[clap(help = "Alias name to unset")]
-    name: String,
-  },
+    #[clap(about = "Unset an alias")]
+    Unset {
+        #[clap(help = "Alias name to unset")]
+        name: String,
+    },
 
-  #[clap(about = "List all aliases")]
-  List,
+    #[clap(about = "List all aliases")]
+    List,
+}
+
+#[derive(Subcommand)]
+pub enum RegistryCommands {
+    #[clap(about = "List predefined registries")]
+    List,
+
+    #[clap(about = "Show current binary registry and version registry")]
+    Show,
+
+    #[clap(about = "Set registry to one of predefined registries")]
+    Set { predefined: RegistryPredefined },
+
+    #[clap(about = "Binary registry operations")]
+    Binary {
+        #[clap(subcommand)]
+        sub: BinaryRegistryCommands,
+    },
+
+    #[clap(about = "Version registry operations")]
+    Version {
+        #[clap(subcommand)]
+        sub: VersionRegistryCommands,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum BinaryRegistryCommands {
+    #[clap(about = "Show current binary registry")]
+    Show,
+    #[clap(about = "Set binary registry to one of predefined registries")]
+    Set { custom: String },
+}
+
+#[derive(Subcommand)]
+pub enum VersionRegistryCommands {
+    #[clap(about = "Show current version registry")]
+    Show,
+    #[clap(about = "Set version registry to one of predefined registries")]
+    Set { custom: String },
+}
+
+#[derive(Clone)]
+pub enum RegistryPredefined {
+    Official,
+    CN,
+}
+
+impl ValueEnum for RegistryPredefined {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[RegistryPredefined::Official, RegistryPredefined::CN]
+    }
+
+    fn from_str(input: &str, ignore_case: bool) -> Result<Self, String> {
+        if (ignore_case && REGISTRY_NAME_OFFICIAL == input.to_ascii_lowercase()) || REGISTRY_NAME_OFFICIAL == input {
+            Ok(RegistryPredefined::Official)
+        } else if (ignore_case && REGISTRY_NAME_CN == input.to_ascii_lowercase()) || REGISTRY_NAME_CN == input {
+            Ok(RegistryPredefined::CN)
+        } else {
+            Err(format!("{} is not a valid registry", input))
+        }
+    }
+
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        Some(PossibleValue::new(match self {
+            RegistryPredefined::Official => REGISTRY_NAME_OFFICIAL,
+            RegistryPredefined::CN => REGISTRY_NAME_CN,
+        }))
+    }
+}
+
+impl RegistryPredefined {
+    pub fn get_version_url(&self) -> String {
+        match self {
+            RegistryPredefined::Official => REGISTRY_LIST_OFFICIAL,
+            RegistryPredefined::CN => REGISTRY_LIST_CN,
+        }
+            .to_string()
+    }
+
+    pub fn get_binary_url(&self) -> String {
+        match self {
+            RegistryPredefined::Official => REGISTRY_OFFICIAL,
+            RegistryPredefined::CN => REGISTRY_CN,
+        }
+            .to_string()
+    }
 }

--- a/src/commands/alias.rs
+++ b/src/commands/alias.rs
@@ -1,5 +1,5 @@
 use crate::cli::AliasCommands;
-use crate::version::{find_max_matching_version, local_versions, remote_versions_or_cached, version_req_parse};
+use crate::version::{find_max_matching_version, local_versions, remote_versions, version_req_parse};
 use crate::{DvmMeta, DEFAULT_ALIAS};
 
 use anyhow::Result;
@@ -34,7 +34,7 @@ pub fn exec(meta: &mut DvmMeta, command: AliasCommands) -> Result<()> {
       Ok(())
     }
     AliasCommands::List => {
-      let remote_versions = remote_versions_or_cached().unwrap();
+      let remote_versions = remote_versions().unwrap();
       let local_versions = local_versions();
       let get_upgrade_version = |version_str: &str| {
         let max_remote_version =

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -22,7 +22,15 @@ pub fn exec(meta: &mut DvmMeta, version: Option<String>, args: Vec<String>) -> R
           let version_req = meta.resolve_version_req(&v);
           match version_req {
             VersionArg::Exact(v) => v.to_string(),
-            VersionArg::Range(r) => best_version(versions.iter().map(AsRef::as_ref), r).unwrap().to_string(),
+            VersionArg::Range(r) => {
+              let best = best_version(versions.iter().map(AsRef::as_ref), r.clone());
+              if let Some(best) = best {
+                best.to_string()
+              } else {
+                eprintln!("No version found for {} in {:?}", r, versions);
+                std::process::exit(1);
+              }
+            }
           }
         })
     }

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -59,7 +59,10 @@ pub fn exec(meta: &DvmMeta, no_use: bool, version: Option<String>) -> Result<()>
   if exe_path.exists() {
     println!("Version v{} is already installed", install_version);
   } else {
-    let archive_data = download_package(&compose_url_to_exec(&meta.registry.binary, &install_version), &install_version)?;
+    let archive_data = download_package(
+      &compose_url_to_exec(&meta.registry.binary, &install_version),
+      &install_version,
+    )?;
     unpack(archive_data, &install_version)?;
   }
 

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -30,8 +30,8 @@ pub fn exec(meta: &DvmMeta, no_use: bool, version: Option<String>) -> Result<()>
     if version == *DVM_VERSION_CANARY {
       let canary_path = deno_canary_path();
       std::fs::create_dir_all(canary_path.parent().unwrap())?;
-      let hash = get_latest_canary(&meta.registry).expect("Failed to get latest canary");
-      let data = download_canary(&meta.registry, &hash)?;
+      let hash = get_latest_canary(&meta.registry.binary).expect("Failed to get latest canary");
+      let data = download_canary(&meta.registry.binary, &hash)?;
       unpack_canary(data)?;
 
       if !no_use {
@@ -51,7 +51,7 @@ pub fn exec(meta: &DvmMeta, no_use: bool, version: Option<String>) -> Result<()>
       }
     },
 
-    None => get_latest_version(&meta.registry)?,
+    None => get_latest_version(&meta.registry.binary)?,
   };
 
   let exe_path = deno_version_path(&install_version);
@@ -59,7 +59,7 @@ pub fn exec(meta: &DvmMeta, no_use: bool, version: Option<String>) -> Result<()>
   if exe_path.exists() {
     println!("Version v{} is already installed", install_version);
   } else {
-    let archive_data = download_package(&compose_url_to_exec(&meta.registry, &install_version), &install_version)?;
+    let archive_data = download_package(&compose_url_to_exec(&meta.registry.binary, &install_version), &install_version)?;
     unpack(archive_data, &install_version)?;
   }
 

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -1,83 +1,79 @@
 use std::process;
 
 use crate::cli::{BinaryRegistryCommands, RegistryCommands, VersionRegistryCommands};
-use crate::consts::{REGISTRY_CN, REGISTRY_LIST_CN, REGISTRY_LIST_OFFICIAL};
 use crate::consts::REGISTRY_NAME_CN;
 use crate::consts::REGISTRY_NAME_OFFICIAL;
 use crate::consts::REGISTRY_OFFICIAL;
+use crate::consts::{REGISTRY_CN, REGISTRY_LIST_CN, REGISTRY_LIST_OFFICIAL};
 use crate::DvmMeta;
 
+use crate::utils::is_http_like_url;
 use anyhow::Result;
 use colored::Colorize;
-use crate::utils::is_http_like_url;
 
 pub fn exec(meta: &mut DvmMeta, registry: RegistryCommands) -> Result<()> {
-    match registry {
-        RegistryCommands::List => {
-            println!("{}:", "official".bright_blue());
-            println!("  binary_registry\t{}", REGISTRY_OFFICIAL);
-            println!("  version_registry\t{}", REGISTRY_LIST_OFFICIAL);
+  match registry {
+    RegistryCommands::List => {
+      println!("{}:", "official".bright_blue());
+      println!("  binary_registry\t{}", REGISTRY_OFFICIAL);
+      println!("  version_registry\t{}", REGISTRY_LIST_OFFICIAL);
 
-            println!("{}:", "cn".bright_blue());
-            println!("  binary_registry\t{}", REGISTRY_CN);
-            println!("  version_registry\t{}", REGISTRY_LIST_CN);
-            println!("Use {} to set the registry.", "dvm registry set <name>".bright_green());
-            println!("for example: {}", "dvm registry set official".bright_green());
+      println!("{}:", "cn".bright_blue());
+      println!("  binary_registry\t{}", REGISTRY_CN);
+      println!("  version_registry\t{}", REGISTRY_LIST_CN);
+      println!("Use {} to set the registry.", "dvm registry set <name>".bright_green());
+      println!("for example: {}", "dvm registry set official".bright_green());
+    }
+    RegistryCommands::Show => {
+      println! {"{}: ", "current registry info".bright_blue()};
+      println!("  binary_registry\t{}", meta.registry.binary);
+      println!("  version_registry\t{}", meta.registry.version);
+    }
+    RegistryCommands::Set { predefined } => {
+      meta.registry.binary = predefined.get_binary_url();
+      meta.registry.version = predefined.get_version_url();
+    }
+    RegistryCommands::Binary { sub } => match sub {
+      BinaryRegistryCommands::Show => {
+        println!("{}: {}", "current binary registry".bright_blue(), meta.registry.binary);
+      }
+      BinaryRegistryCommands::Set { custom } => {
+        if custom == REGISTRY_NAME_OFFICIAL {
+          meta.registry.binary = REGISTRY_OFFICIAL.to_string();
+        } else if custom == REGISTRY_NAME_CN {
+          meta.registry.binary = REGISTRY_CN.to_string();
+        } else if is_http_like_url(&custom) {
+          meta.registry.binary = custom;
+        } else {
+          println!("{}: {}", "invalid registry".bright_red(), custom);
+          process::exit(1);
         }
-        RegistryCommands::Show => {
-            println! {"{}: ", "current registry info".bright_blue()};
-            println!("  binary_registry\t{}", meta.registry.binary);
-            println!("  version_registry\t{}", meta.registry.version);
+      }
+    },
+    RegistryCommands::Version { sub } => match sub {
+      VersionRegistryCommands::Show => {
+        println!(
+          "{}: {}",
+          "current version registry".bright_blue(),
+          meta.registry.version
+        );
+      }
+      VersionRegistryCommands::Set { custom } => {
+        if custom == REGISTRY_NAME_OFFICIAL {
+          meta.registry.version = REGISTRY_LIST_OFFICIAL.to_string();
+        } else if custom == REGISTRY_NAME_CN {
+          meta.registry.version = REGISTRY_LIST_CN.to_string();
+        } else if is_http_like_url(&custom) {
+          meta.registry.version = custom;
+        } else {
+          eprintln!("The {} is not valid URL, please starts with `http` or `https`", custom);
+          eprintln!("Registry will not be changed");
+          process::exit(1)
         }
-        RegistryCommands::Set { predefined } => {
-            meta.registry.binary = predefined.get_binary_url();
-            meta.registry.version = predefined.get_version_url();
-        }
-        RegistryCommands::Binary { sub } => {
-            match sub {
-                BinaryRegistryCommands::Show => {
-                    println!("{}: {}", "current binary registry".bright_blue(), meta.registry.binary);
-                }
-                BinaryRegistryCommands::Set { custom } => {
-                    if custom == REGISTRY_NAME_OFFICIAL {
-                        meta.registry.binary = REGISTRY_OFFICIAL.to_string();
-                    } else if custom == REGISTRY_NAME_CN {
-                        meta.registry.binary = REGISTRY_CN.to_string();
-                    } else if is_http_like_url(&custom) {
-                        meta.registry.binary = custom;
-                    } else {
-                        println!("{}: {}", "invalid registry".bright_red(), custom);
-                        process::exit(1);
-                    }
-                }
-            }
-        }
-        RegistryCommands::Version { sub } => {
-            match sub {
-                VersionRegistryCommands::Show => {
-                    println!("{}: {}", "current version registry".bright_blue(), meta.registry.version);
-                }
-                VersionRegistryCommands::Set { custom } => {
-                    if custom == REGISTRY_NAME_OFFICIAL {
-                        meta.registry.version = REGISTRY_LIST_OFFICIAL.to_string();
-                    } else if custom == REGISTRY_NAME_CN {
-                        meta.registry.version = REGISTRY_LIST_CN.to_string();
-                    } else if is_http_like_url(&custom) {
-                        meta.registry.version = custom;
-                    } else {
-                        eprintln!(
-                            "The {} is not valid URL, please starts with `http` or `https`",
-                            custom
-                        );
-                        eprintln!("Registry will not be changed");
-                        process::exit(1)
-                    }
-                }
-            }
-        }
-    };
+      }
+    },
+  };
 
-    meta.save();
-    Ok(())
+  meta.save();
+  Ok(())
 }
-

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -7,7 +7,7 @@ use crate::consts::{DVM_CONFIGRC_KEY_REGISTRY_BINARY, DVM_CONFIGRC_KEY_REGISTRY_
 use crate::consts::{REGISTRY_CN, REGISTRY_LIST_CN, REGISTRY_LIST_OFFICIAL};
 use crate::DvmMeta;
 
-use crate::configrc::{rc_exists, rc_get, rc_init, rc_update};
+use crate::configrc::{rc_get, rc_update};
 use crate::utils::is_http_like_url;
 use anyhow::Result;
 use colored::Colorize;
@@ -15,10 +15,6 @@ use colored::Colorize;
 pub fn exec(meta: &mut DvmMeta, registry: RegistryCommands) -> Result<()> {
   let rc_binary_registry = rc_get(DVM_CONFIGRC_KEY_REGISTRY_BINARY).unwrap_or_else(|_| REGISTRY_OFFICIAL.to_string());
   let rc_version_registry = rc_get(DVM_CONFIGRC_KEY_REGISTRY_VERSION).unwrap_or_else(|_| REGISTRY_OFFICIAL.to_string());
-
-  if !rc_exists() {
-    rc_init()?;
-  }
 
   match registry {
     RegistryCommands::List => {
@@ -41,7 +37,6 @@ pub fn exec(meta: &mut DvmMeta, registry: RegistryCommands) -> Result<()> {
       predefined,
       write_local,
     } => {
-      let write_local = write_local.unwrap_or(false);
       rc_update(
         write_local,
         DVM_CONFIGRC_KEY_REGISTRY_BINARY,

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -1,36 +1,83 @@
 use std::process;
 
-use crate::consts::REGISTRY_CN;
+use crate::cli::{BinaryRegistryCommands, RegistryCommands, VersionRegistryCommands};
+use crate::consts::{REGISTRY_CN, REGISTRY_LIST_CN, REGISTRY_LIST_OFFICIAL};
 use crate::consts::REGISTRY_NAME_CN;
 use crate::consts::REGISTRY_NAME_OFFICIAL;
 use crate::consts::REGISTRY_OFFICIAL;
 use crate::DvmMeta;
 
 use anyhow::Result;
+use colored::Colorize;
+use crate::utils::is_http_like_url;
 
-pub fn exec(meta: &mut DvmMeta, registry: Option<String>) -> Result<()> {
-  let registry = registry.unwrap_or_else(|| REGISTRY_NAME_OFFICIAL.to_string());
+pub fn exec(meta: &mut DvmMeta, registry: RegistryCommands) -> Result<()> {
+    match registry {
+        RegistryCommands::List => {
+            println!("{}:", "official".bright_blue());
+            println!("  binary_registry\t{}", REGISTRY_OFFICIAL);
+            println!("  version_registry\t{}", REGISTRY_LIST_OFFICIAL);
 
-  if registry == *REGISTRY_NAME_OFFICIAL {
-    meta.registry = REGISTRY_OFFICIAL.to_string();
-    println!("Registry now set to the official registry \"{}\"", REGISTRY_OFFICIAL);
-  } else if registry == *REGISTRY_NAME_CN {
-    meta.registry = REGISTRY_CN.to_string();
-    println!(
-      "Registry now set to the CN mirror (that provided by @justjavac) \"{}\"",
-      REGISTRY_CN
-    )
-  } else if registry.starts_with("http://") || registry.starts_with("https://") {
-    meta.registry = registry;
-  } else {
-    eprintln!(
-      "The {} is not valid URL, please starts with `http` or `https`",
-      registry
-    );
-    eprintln!("Registry will not be changed");
-    process::exit(1)
-  }
+            println!("{}:", "cn".bright_blue());
+            println!("  binary_registry\t{}", REGISTRY_CN);
+            println!("  version_registry\t{}", REGISTRY_LIST_CN);
+            println!("Use {} to set the registry.", "dvm registry set <name>".bright_green());
+            println!("for example: {}", "dvm registry set official".bright_green());
+        }
+        RegistryCommands::Show => {
+            println! {"{}: ", "current registry info".bright_blue()};
+            println!("  binary_registry\t{}", meta.registry.binary);
+            println!("  version_registry\t{}", meta.registry.version);
+        }
+        RegistryCommands::Set { predefined } => {
+            meta.registry.binary = predefined.get_binary_url();
+            meta.registry.version = predefined.get_version_url();
+        }
+        RegistryCommands::Binary { sub } => {
+            match sub {
+                BinaryRegistryCommands::Show => {
+                    println!("{}: {}", "current binary registry".bright_blue(), meta.registry.binary);
+                }
+                BinaryRegistryCommands::Set { custom } => {
+                    if custom == REGISTRY_NAME_OFFICIAL {
+                        meta.registry.binary = REGISTRY_OFFICIAL.to_string();
+                    } else if custom == REGISTRY_NAME_CN {
+                        meta.registry.binary = REGISTRY_CN.to_string();
+                    } else if is_http_like_url(&custom) {
+                        meta.registry.binary = custom;
+                    } else {
+                        println!("{}: {}", "invalid registry".bright_red(), custom);
+                        process::exit(1);
+                    }
+                }
+            }
+        }
+        RegistryCommands::Version { sub } => {
+            match sub {
+                VersionRegistryCommands::Show => {
+                    println!("{}: {}", "current version registry".bright_blue(), meta.registry.version);
+                }
+                VersionRegistryCommands::Set { custom } => {
+                    if custom == REGISTRY_NAME_OFFICIAL {
+                        meta.registry.version = REGISTRY_LIST_OFFICIAL.to_string();
+                    } else if custom == REGISTRY_NAME_CN {
+                        meta.registry.version = REGISTRY_LIST_CN.to_string();
+                    } else if is_http_like_url(&custom) {
+                        meta.registry.version = custom;
+                    } else {
+                        eprintln!(
+                            "The {} is not valid URL, please starts with `http` or `https`",
+                            custom
+                        );
+                        eprintln!("Registry will not be changed");
+                        process::exit(1)
+                    }
+                }
+            }
+        }
+    };
 
-  meta.save();
-  Ok(())
+    meta.save();
+    Ok(())
 }
+

--- a/src/commands/use_version.rs
+++ b/src/commands/use_version.rs
@@ -1,5 +1,5 @@
 use crate::commands::install;
-use crate::consts::{DVM_CONFIG_FILENAME, DVM_VERSION_CANARY, DVM_VERSION_LATEST, DVM_VERSION_SYSTEM};
+use crate::consts::{DVM_CONFIGRC_FILENAME, DVM_VERSION_CANARY, DVM_VERSION_LATEST, DVM_VERSION_SYSTEM};
 use crate::deno_bin_path;
 use crate::meta::DvmMeta;
 use crate::utils::{best_version, deno_canary_path, deno_version_path, prompt_request, update_stub};
@@ -113,10 +113,13 @@ pub fn use_canary_bin_path(local: bool) -> Result<()> {
 
   if local {
     println!("Writing to current folder config");
-    fs::write(std::path::Path::new(DVM_CONFIG_FILENAME), DVM_VERSION_CANARY)?;
+    fs::write(std::path::Path::new(DVM_CONFIGRC_FILENAME), DVM_VERSION_CANARY)?;
   } else {
     println!("Writing to home folder config");
-    fs::write(dirs::home_dir().unwrap().join(DVM_CONFIG_FILENAME), DVM_VERSION_CANARY)?;
+    fs::write(
+      dirs::home_dir().unwrap().join(DVM_CONFIGRC_FILENAME),
+      DVM_VERSION_CANARY,
+    )?;
   }
 
   println!("Now using deno canary");
@@ -137,10 +140,10 @@ pub fn use_this_bin_path(exe_path: &Path, version: &Version, raw_version: String
 
   if local {
     println!("Writing to current folder config");
-    fs::write(std::path::Path::new(DVM_CONFIG_FILENAME), raw_version)?;
+    fs::write(std::path::Path::new(DVM_CONFIGRC_FILENAME), raw_version)?;
   } else {
     println!("Writing to home folder config");
-    fs::write(dirs::home_dir().unwrap().join(DVM_CONFIG_FILENAME), raw_version)?;
+    fs::write(dirs::home_dir().unwrap().join(DVM_CONFIGRC_FILENAME), raw_version)?;
   }
   println!("Now using deno {}", version);
   Ok(())

--- a/src/commands/use_version.rs
+++ b/src/commands/use_version.rs
@@ -55,7 +55,7 @@ pub fn exec(meta: &mut DvmMeta, version: Option<String>, local: bool) -> Result<
 
   let used_version = if version_req.to_string() == "*" {
     println!("Checking for latest version");
-    let version = get_latest_version(&meta.registry).expect("Get latest version failed");
+    let version = get_latest_version(&meta.registry.binary).expect("Get latest version failed");
     println!("The latest version is v{}", version);
     version
   } else {

--- a/src/configrc.rs
+++ b/src/configrc.rs
@@ -2,8 +2,23 @@ use crate::consts::{
   DVM_CONFIGRC_FILENAME, DVM_CONFIGRC_KEY_DENO_VERSION, DVM_CONFIGRC_KEY_REGISTRY_BINARY,
   DVM_CONFIGRC_KEY_REGISTRY_VERSION,
 };
+use crate::consts::{REGISTRY_LIST_OFFICIAL, REGISTRY_OFFICIAL};
 use std::fs;
 use std::io;
+
+/// check global rc file exists
+pub fn rc_exists() -> bool {
+  let dir = dirs::home_dir()
+    .and_then(|it| Some(it.join(DVM_CONFIGRC_FILENAME)))
+    .unwrap_or_default();
+  fs::metadata(dir).is_ok()
+}
+
+/// init user-wide rc file
+pub fn rc_init() -> io::Result<()> {
+  rc_update(false, DVM_CONFIGRC_KEY_REGISTRY_BINARY, REGISTRY_OFFICIAL)?;
+  rc_update(false, DVM_CONFIGRC_KEY_REGISTRY_VERSION, REGISTRY_LIST_OFFICIAL)
+}
 
 /// get value by key from configrc
 /// first try to get from current folder
@@ -75,11 +90,11 @@ fn rc_content(is_local: bool) -> io::Result<(std::path::PathBuf, String)> {
     std::path::PathBuf::from(DVM_CONFIGRC_FILENAME)
   } else {
     dirs::home_dir()
-      .ok_or_else(|| io::Error::from(io::ErrorKind::NotFound))?
+      .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "helllllll"))?
       .join(DVM_CONFIGRC_FILENAME)
   };
 
-  Ok((config_path.to_path_buf(), fs::read_to_string(config_path)?))
+  Ok((config_path.clone(), fs::read_to_string(config_path)?))
 }
 
 /// remove all key value pair that ain't supported by dvm from config file

--- a/src/configrc.rs
+++ b/src/configrc.rs
@@ -41,7 +41,6 @@ pub fn rc_get(key: &str) -> io::Result<String> {
 /// update the config file key with the new value
 /// create the file if it doesn't exist
 /// create key value pair if it doesn't exist
-#[allow(dead_code)]
 pub fn rc_update(is_local: bool, key: &str, value: &str) -> io::Result<()> {
   let (config_path, content) = rc_content(is_local).unwrap_or_default();
   let mut config = rc_parse(content.as_str());

--- a/src/configrc.rs
+++ b/src/configrc.rs
@@ -93,7 +93,7 @@ fn rc_content(is_local: bool) -> io::Result<(std::path::PathBuf, String)> {
     std::path::PathBuf::from(DVM_CONFIGRC_FILENAME)
   } else {
     dirs::home_dir()
-      .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "helllllll"))?
+      .ok_or_else(|| io::Error::from(io::ErrorKind::NotFound))?
       .join(DVM_CONFIGRC_FILENAME)
   };
 

--- a/src/configrc.rs
+++ b/src/configrc.rs
@@ -1,0 +1,119 @@
+use crate::consts::{
+  DVM_CONFIGRC_FILENAME, DVM_CONFIGRC_KEY_DENO_VERSION, DVM_CONFIGRC_KEY_REGISTRY_BINARY,
+  DVM_CONFIGRC_KEY_REGISTRY_VERSION,
+};
+use std::fs;
+use std::io;
+
+/// get value by key from configrc
+/// first try to get from current folder
+/// if not found, try to get from home folder
+/// if not found, return Err
+pub fn rc_get(key: &str) -> io::Result<String> {
+  let (_, content) = rc_content(true).or_else(|_| rc_content(false))?;
+  let config = rc_parse(content.as_str());
+
+  config
+    .iter()
+    .find_map(|(k, v)| if k == &key { Some(v.to_string()) } else { None })
+    .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "key not found"))
+}
+
+/// update the config file key with the new value
+/// create the file if it doesn't exist
+/// create key value pair if it doesn't exist
+#[allow(dead_code)]
+pub fn rc_update(is_local: bool, key: &str, value: &str) -> io::Result<()> {
+  let (config_path, content) = rc_content(is_local).unwrap_or_default();
+  let mut config = rc_parse(content.as_str());
+
+  let idx = config.iter().position(|(k, _)| k == &key);
+  if let Some(idx) = idx {
+    config[idx].1 = value;
+  } else {
+    config.push((key, value));
+  }
+
+  let config = config
+    .iter()
+    .map(|(k, v)| format!("{}={}", k, v))
+    .collect::<Vec<_>>()
+    .join("\n");
+  fs::write(config_path, config)
+}
+
+/// remove key value pair from config file
+#[allow(dead_code)]
+pub fn rc_remove(is_local: bool, key: &str) -> io::Result<()> {
+  let (config_path, content) = rc_content(is_local).unwrap_or_default();
+  let config = rc_parse(content.as_str());
+  let config = config.iter().filter(|(k, _)| k != &key).collect::<Vec<_>>();
+
+  let config = config
+    .iter()
+    .map(|(k, v)| format!("{}={}", k, v))
+    .collect::<Vec<_>>()
+    .join("\n");
+  fs::write(config_path, config)
+}
+
+fn rc_parse(content: &str) -> Vec<(&str, &str)> {
+  let config = content
+    .lines()
+    .map(|line| {
+      let mut parts = line.splitn(2, '=');
+      let k = parts.next().unwrap();
+      let v = parts.next().unwrap_or("");
+      (k, v)
+    })
+    .collect::<Vec<_>>();
+  config
+}
+
+fn rc_content(is_local: bool) -> io::Result<(std::path::PathBuf, String)> {
+  let config_path = if is_local {
+    std::path::PathBuf::from(DVM_CONFIGRC_FILENAME)
+  } else {
+    dirs::home_dir()
+      .ok_or_else(|| io::Error::from(io::ErrorKind::NotFound))?
+      .join(DVM_CONFIGRC_FILENAME)
+  };
+
+  Ok((config_path.to_path_buf(), fs::read_to_string(config_path)?))
+}
+
+/// remove all key value pair that ain't supported by dvm from config file
+#[allow(dead_code)]
+pub fn rc_clean(is_local: bool) -> io::Result<()> {
+  let (config_path, content) = rc_content(is_local).unwrap_or_default();
+  let config = rc_parse(content.as_str());
+  let config = config
+    .iter()
+    .filter(|(k, _)| {
+      k == &DVM_CONFIGRC_KEY_DENO_VERSION
+        || k == &DVM_CONFIGRC_KEY_REGISTRY_BINARY
+        || k == &DVM_CONFIGRC_KEY_REGISTRY_VERSION
+    })
+    .collect::<Vec<_>>();
+
+  let config = config
+    .iter()
+    .map(|(k, v)| format!("{}={}", k, v))
+    .collect::<Vec<_>>()
+    .join("\n");
+  fs::write(config_path, config)
+}
+
+/// clear and delete the rc file
+/// if is_local is true, delete the local rc file
+/// if is_local is false, delete the global(user-wide) rc file
+#[allow(dead_code)]
+pub fn rc_clear(is_local: bool) -> io::Result<()> {
+  if is_local {
+    std::fs::remove_file(DVM_CONFIGRC_FILENAME)
+  } else {
+    let home_dir = dirs::home_dir().ok_or_else(|| io::Error::from(io::ErrorKind::NotFound))?;
+    let rc_file = home_dir.join(DVM_CONFIGRC_FILENAME);
+    std::fs::remove_file(rc_file)
+  }
+}

--- a/src/configrc.rs
+++ b/src/configrc.rs
@@ -9,7 +9,7 @@ use std::io;
 /// check global rc file exists
 pub fn rc_exists() -> bool {
   let dir = dirs::home_dir()
-    .and_then(|it| Some(it.join(DVM_CONFIGRC_FILENAME)))
+    .map(|it| it.join(DVM_CONFIGRC_FILENAME))
     .unwrap_or_default();
   fs::metadata(dir).is_ok()
 }
@@ -25,6 +25,10 @@ pub fn rc_init() -> io::Result<()> {
 /// if not found, try to get from home folder
 /// if not found, return Err
 pub fn rc_get(key: &str) -> io::Result<String> {
+  if !rc_exists() {
+    rc_init()?;
+  }
+
   let (_, content) = rc_content(true).or_else(|_| rc_content(false))?;
   let config = rc_parse(content.as_str());
 
@@ -94,7 +98,7 @@ fn rc_content(is_local: bool) -> io::Result<(std::path::PathBuf, String)> {
       .join(DVM_CONFIGRC_FILENAME)
   };
 
-  Ok((config_path.clone(), fs::read_to_string(config_path)?))
+  Ok((config_path.clone(), fs::read_to_string(config_path).unwrap_or_default()))
 }
 
 /// remove all key value pair that ain't supported by dvm from config file

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,7 +1,7 @@
 pub const REGISTRY_OFFICIAL: &str = "https://dl.deno.land/";
 pub const REGISTRY_CN: &str = "https://dl.deno.js.cn/";
-pub const REGISTRY_LIST_OFFICIAL: &str = "https://api.github.com/repos/denoland/deno/tags";
-pub const REGISTRY_LIST_CN: &str = "https://cdn.jsdelivr.net/gh/denoland/dotland@main/versions.json";
+pub const REGISTRY_LIST_OFFICIAL: &str = "https://raw.githubusercontent.com/denoland/dotland/main/versions.json";
+pub const REGISTRY_LIST_CN: &str = "https://dl.deno.js.cn/versions.json";
 
 pub const REGISTRY_LATEST_RELEASE_PATH: &str = "release-latest.txt";
 pub const REGISTRY_LATEST_CANARY_PATH: &str = "canary-latest.txt";
@@ -9,11 +9,15 @@ pub const REGISTRY_NAME_CN: &str = "cn";
 pub const REGISTRY_NAME_OFFICIAL: &str = "official";
 
 pub const DVM_CACHE_PATH_PREFIX: &str = "versions";
+#[allow(dead_code)]
 pub const DVM_CACHE_REMOTE_PATH: &str = "cached-remote-versions.json";
 pub const DVM_CANARY_PATH_PREFIX: &str = "canary";
 pub const DVM_CACHE_INVALID_TIMEOUT: u128 = 60 * 60 * 24 * 7;
 
-pub const DVM_CONFIG_FILENAME: &str = ".dvmrc";
+pub const DVM_CONFIGRC_FILENAME: &str = ".dvmrc";
+pub const DVM_CONFIGRC_KEY_DENO_VERSION: &str = "deno_version";
+pub const DVM_CONFIGRC_KEY_REGISTRY_VERSION: &str = "registry_version";
+pub const DVM_CONFIGRC_KEY_REGISTRY_BINARY: &str = "registry_binary";
 
 pub const DVM_VERSION_CANARY: &str = "canary";
 pub const DVM_VERSION_LATEST: &str = "latest";

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,6 +1,8 @@
 pub const REGISTRY_OFFICIAL: &str = "https://dl.deno.land/";
-#[allow(unused)]
 pub const REGISTRY_CN: &str = "https://dl.deno.js.cn/";
+pub const REGISTRY_LIST_OFFICIAL: &str = "https://api.github.com/repos/denoland/deno/tags";
+pub const REGISTRY_LIST_CN: &str = "https://cdn.jsdelivr.net/gh/denoland/dotland@main/versions.json";
+
 pub const REGISTRY_LATEST_RELEASE_PATH: &str = "release-latest.txt";
 pub const REGISTRY_LATEST_CANARY_PATH: &str = "canary-latest.txt";
 pub const REGISTRY_NAME_CN: &str = "cn";
@@ -17,9 +19,6 @@ pub const DVM_VERSION_CANARY: &str = "canary";
 pub const DVM_VERSION_LATEST: &str = "latest";
 pub const DVM_VERSION_SYSTEM: &str = "system";
 pub const DVM_VERSION_INVALID: &str = "N/A";
-
-pub const DVM_CHINA_MAINLAND_REGISTRY: &str = "https://cdn.jsdelivr.net/gh/denoland/dotland@main/versions.json";
-pub const DVM_INTERNATIONAL_REGISTRY: &str = "https://api.github.com/repos/denoland/deno/tags";
 
 cfg_if::cfg_if! {
   if #[cfg(windows)] {

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ pub fn main() {
     Commands::List => commands::list::exec(),
     Commands::ListRemote => commands::list::exec_remote(),
     Commands::Uninstall { version } => commands::uninstall::exec(version),
-    Commands::Use { version, local } => commands::use_version::exec(&mut meta, version, local),
+    Commands::Use { version, write_local } => commands::use_version::exec(&mut meta, version, write_local),
     Commands::Alias { command } => commands::alias::exec(&mut meta, command),
     Commands::Activate => commands::activate::exec(&mut meta),
     Commands::Deactivate => commands::deactivate::exec(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,15 +47,12 @@ pub fn main() {
     Commands::Deactivate => commands::deactivate::exec(),
     Commands::Doctor => commands::doctor::exec(&mut meta),
     Commands::Upgrade { alias } => commands::upgrade::exec(&mut meta, alias),
-    Commands::Exec {
-      command: _,
-      deno_version: _,
-    } => {
+    Commands::Exec { command: _, version: _ } => {
       /* unused */
       Ok(())
     }
     Commands::Clean => commands::clean::exec(&mut meta),
-    Commands::Registry { registry } => commands::registry::exec(&mut meta, registry),
+    Commands::Registry { command } => commands::registry::exec(&mut meta, command),
   };
 
   if let Err(err) = result {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ extern crate core;
 
 mod cli;
 mod commands;
+mod configrc;
 mod consts;
 mod meta;
 mod utils;

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -1,4 +1,4 @@
-use crate::consts::{DVM_CACHE_INVALID_TIMEOUT, };
+use crate::consts::DVM_CACHE_INVALID_TIMEOUT;
 use crate::utils::{deno_version_path, dvm_root, dvm_versions, now};
 use crate::version::VersionArg;
 use colored::Colorize;

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -13,327 +13,327 @@ pub const DEFAULT_ALIAS: phf::Map<&'static str, &'static str> = phf::phf_map! {
 };
 
 pub trait ToVersionReq {
-    fn to_version_req(&self) -> VersionReq;
-    fn try_to_version_req(&self) -> anyhow::Result<VersionReq>;
+  fn to_version_req(&self) -> VersionReq;
+  fn try_to_version_req(&self) -> anyhow::Result<VersionReq>;
 }
 
 #[derive(Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct VersionMapping {
-    pub required: String,
-    pub current: String,
+  pub required: String,
+  pub current: String,
 }
 
 impl VersionMapping {
-    pub fn is_valid_mapping(&self) -> bool {
-        let current = Version::parse(&self.current);
-        if current.is_err() {
-            return false;
-        }
-        let current = current.unwrap();
-
-        let req = self.try_to_version_req();
-        if req.is_err() {
-            return false;
-        }
-        let req = req.unwrap();
-
-        req.matches(&current)
+  pub fn is_valid_mapping(&self) -> bool {
+    let current = Version::parse(&self.current);
+    if current.is_err() {
+      return false;
     }
+    let current = current.unwrap();
+
+    let req = self.try_to_version_req();
+    if req.is_err() {
+      return false;
+    }
+    let req = req.unwrap();
+
+    req.matches(&current)
+  }
 }
 
 impl ToVersionReq for VersionMapping {
-    fn to_version_req(&self) -> VersionReq {
-        VersionReq::from_str(&self.required).expect("VersionMapping::required is not a valid VersionReq")
-    }
+  fn to_version_req(&self) -> VersionReq {
+    VersionReq::from_str(&self.required).expect("VersionMapping::required is not a valid VersionReq")
+  }
 
-    fn try_to_version_req(&self) -> anyhow::Result<VersionReq> {
-        VersionReq::from_str(&self.required).map_err(|err| anyhow::anyhow!(err))
-    }
+  fn try_to_version_req(&self) -> anyhow::Result<VersionReq> {
+    VersionReq::from_str(&self.required).map_err(|err| anyhow::anyhow!(err))
+  }
 }
 
 #[derive(Clone, Eq, PartialEq, Deserialize, Serialize, Debug)]
 pub struct Alias {
-    pub name: String,
-    pub required: String,
+  pub name: String,
+  pub required: String,
 }
 
 impl ToVersionReq for Alias {
-    fn to_version_req(&self) -> VersionReq {
-        VersionReq::from_str(&self.required).expect("Alias::required is not a valid VersionReq")
-    }
+  fn to_version_req(&self) -> VersionReq {
+    VersionReq::from_str(&self.required).expect("Alias::required is not a valid VersionReq")
+  }
 
-    fn try_to_version_req(&self) -> anyhow::Result<VersionReq> {
-        VersionReq::from_str(&self.required).map_err(|err| anyhow::anyhow!(err))
-    }
+  fn try_to_version_req(&self) -> anyhow::Result<VersionReq> {
+    VersionReq::from_str(&self.required).map_err(|err| anyhow::anyhow!(err))
+  }
 }
 
 #[derive(Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct Registry {
-    pub binary: String,
-    pub version: String,
+  pub binary: String,
+  pub version: String,
 }
 
 impl Default for Registry {
-    fn default() -> Self {
-        Registry {
-            binary: REGISTRY_OFFICIAL.to_string(),
-            version: REGISTRY_LIST_OFFICIAL.to_string(),
-        }
+  fn default() -> Self {
+    Registry {
+      binary: REGISTRY_OFFICIAL.to_string(),
+      version: REGISTRY_LIST_OFFICIAL.to_string(),
     }
+  }
 }
 
 #[derive(Clone, Default, Eq, PartialEq, Deserialize, Serialize)]
 pub struct DvmMeta {
-    pub registry: Registry,
-    pub versions: Vec<VersionMapping>,
-    pub alias: Vec<Alias>,
+  pub registry: Registry,
+  pub versions: Vec<VersionMapping>,
+  pub alias: Vec<Alias>,
 }
 
 impl DvmMeta {
-    pub fn path() -> PathBuf {
-        let mut meta = dvm_root();
-        meta.push(Path::new("dvm-metadata.json"));
-        meta
-    }
+  pub fn path() -> PathBuf {
+    let mut meta = dvm_root();
+    meta.push(Path::new("dvm-metadata.json"));
+    meta
+  }
 
-    pub fn new() -> Self {
-        let path = DvmMeta::path();
-        if path.exists() {
-            let content = read_to_string(path);
-            if let Ok(content) = content {
-                let config = serde_json::from_str::<DvmMeta>(content.as_str());
-                if let Ok(mut config) = config {
-                    let mut i = 0;
-                    while i < config.versions.len() {
-                        if !deno_version_path(&Version::parse(&config.versions[i].current).unwrap()).exists() {
-                            config.versions.remove(i);
-                        } else {
-                            i += 1;
-                        }
-                    }
-                    return config;
-                }
+  pub fn new() -> Self {
+    let path = DvmMeta::path();
+    if path.exists() {
+      let content = read_to_string(path);
+      if let Ok(content) = content {
+        let config = serde_json::from_str::<DvmMeta>(content.as_str());
+        if let Ok(mut config) = config {
+          let mut i = 0;
+          while i < config.versions.len() {
+            if !deno_version_path(&Version::parse(&config.versions[i].current).unwrap()).exists() {
+              config.versions.remove(i);
+            } else {
+              i += 1;
             }
+          }
+          return config;
         }
-
-        let mut config = DvmMeta::default();
-        config.save_and_reload();
-        config
+      }
     }
 
-    pub fn clean_files(&self) {
-        let cache_folder = dvm_versions();
-        if let Ok(dir) = cache_folder.read_dir() {
-            for entry in dir.flatten() {
-                let path = entry.path();
-                if path.is_dir() {
-                    let name = path.file_name().unwrap().to_str().unwrap();
+    let mut config = DvmMeta::default();
+    config.save_and_reload();
+    config
+  }
 
-                    // it's been pointed by dvm versions
-                    if self.versions.iter().any(|it| it.current == name) {
-                        continue;
-                    }
+  pub fn clean_files(&self) {
+    let cache_folder = dvm_versions();
+    if let Ok(dir) = cache_folder.read_dir() {
+      for entry in dir.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+          let name = path.file_name().unwrap().to_str().unwrap();
 
-                    // it's not been outdated
-                    let stub = path.join(".dvmstub");
-                    if stub.exists() && stub.is_file() {
-                        let content = std::fs::read_to_string(stub).expect("read stub file failed");
-                        let content: u128 = content.parse().expect("parse stub file failed");
-                        if content > now() - DVM_CACHE_INVALID_TIMEOUT {
-                            continue;
-                        }
-                    }
+          // it's been pointed by dvm versions
+          if self.versions.iter().any(|it| it.current == name) {
+            continue;
+          }
 
-                    println!("Cleaning version {}", name.bright_black());
-                    std::fs::remove_dir_all(path).unwrap();
-                }
+          // it's not been outdated
+          let stub = path.join(".dvmstub");
+          if stub.exists() && stub.is_file() {
+            let content = std::fs::read_to_string(stub).expect("read stub file failed");
+            let content: u128 = content.parse().expect("parse stub file failed");
+            if content > now() - DVM_CACHE_INVALID_TIMEOUT {
+              continue;
             }
+          }
+
+          println!("Cleaning version {}", name.bright_black());
+          std::fs::remove_dir_all(path).unwrap();
         }
+      }
+    }
+  }
+
+  ///
+  /// set a version mapping
+  ///   `required` is either a semver range or a alias to a semver rage
+  ///   `current` is the current directory that the deno located in
+  pub fn set_version_mapping(&mut self, required: String, current: String) {
+    let result = self.versions.iter().position(|it| it.required == required);
+    if let Some(index) = result {
+      self.versions[index] = VersionMapping { required, current };
+    } else {
+      self.versions.push(VersionMapping { required, current });
+    }
+    self.save_and_reload();
+  }
+
+  ///
+  /// get fold name of a given mapping,
+  /// None if there haven't a deno version met the required semver range or alias that
+  /// are installed already
+  pub fn get_version_mapping(&self, required: &str) -> Option<String> {
+    self
+      .versions
+      .iter()
+      .position(|it| it.required == required)
+      .map(|index| self.versions[index].current.clone())
+  }
+
+  ///
+  /// delete a version mapping
+  /// this will also delete actual files.
+  pub fn delete_version_mapping(&mut self, required: String) {
+    let result = self.versions.iter().position(|it| it.required == required);
+    if let Some(index) = result {
+      self.versions.remove(index);
     }
 
-    ///
-    /// set a version mapping
-    ///   `required` is either a semver range or a alias to a semver rage
-    ///   `current` is the current directory that the deno located in
-    pub fn set_version_mapping(&mut self, required: String, current: String) {
-        let result = self.versions.iter().position(|it| it.required == required);
-        if let Some(index) = result {
-            self.versions[index] = VersionMapping { required, current };
-        } else {
-            self.versions.push(VersionMapping { required, current });
-        }
-        self.save_and_reload();
+    self.save_and_reload();
+  }
+
+  ///
+  /// list aliases
+  /// including predefined aliases
+  pub fn list_alias(&self) -> Vec<Alias> {
+    let mut alias = self.alias.clone();
+    for (k, v) in DEFAULT_ALIAS.into_iter() {
+      alias.insert(
+        0,
+        Alias {
+          name: k.to_string(),
+          required: v.to_string(),
+        },
+      );
     }
 
-    ///
-    /// get fold name of a given mapping,
-    /// None if there haven't a deno version met the required semver range or alias that
-    /// are installed already
-    pub fn get_version_mapping(&self, required: &str) -> Option<String> {
-        self
-            .versions
-            .iter()
-            .position(|it| it.required == required)
-            .map(|index| self.versions[index].current.clone())
+    alias
+  }
+
+  /// set a alias
+  ///   name is alias name
+  ///   required is a semver range
+  pub fn set_alias(&mut self, name: String, required: String) {
+    if DEFAULT_ALIAS.contains_key(name.as_str()) {
+      return;
+    }
+    let result = self.alias.iter().position(|it| it.name == name);
+    if let Some(index) = result {
+      self.alias[index] = Alias { name, required };
+    } else {
+      self.alias.push(Alias { name, required });
     }
 
-    ///
-    /// delete a version mapping
-    /// this will also delete actual files.
-    pub fn delete_version_mapping(&mut self, required: String) {
-        let result = self.versions.iter().position(|it| it.required == required);
-        if let Some(index) = result {
-            self.versions.remove(index);
-        }
+    self.save_and_reload();
+  }
 
-        self.save_and_reload();
+  pub fn has_alias(&self, name: &str) -> bool {
+    self.get_alias(name).is_some()
+  }
+
+  /// get the semver range of alias
+  pub fn get_alias(&self, name: &str) -> Option<VersionArg> {
+    if DEFAULT_ALIAS.contains_key(name) {
+      VersionArg::from_str(DEFAULT_ALIAS[name]).ok()
+    } else {
+      self
+        .alias
+        .iter()
+        .position(|it| it.name == name)
+        .map(|index| VersionArg::from_str(&self.alias[index].required).unwrap())
+    }
+  }
+
+  /// delete a alias
+  pub fn delete_alias(&mut self, name: String) {
+    let result = self.alias.iter().position(|it| it.name == name);
+    if let Some(index) = result {
+      self.alias.remove(index);
     }
 
-    ///
-    /// list aliases
-    /// including predefined aliases
-    pub fn list_alias(&self) -> Vec<Alias> {
-        let mut alias = self.alias.clone();
-        for (k, v) in DEFAULT_ALIAS.into_iter() {
-            alias.insert(
-                0,
-                Alias {
-                    name: k.to_string(),
-                    required: v.to_string(),
-                },
-            );
-        }
+    self.save_and_reload();
+  }
 
-        alias
+  pub fn resolve_version_req(&self, required: &str) -> VersionArg {
+    if self.has_alias(required) {
+      self.get_alias(required).unwrap()
+    } else {
+      VersionArg::from_str(required).unwrap()
     }
+  }
 
-    /// set a alias
-    ///   name is alias name
-    ///   required is a semver range
-    pub fn set_alias(&mut self, name: String, required: String) {
-        if DEFAULT_ALIAS.contains_key(name.as_str()) {
-            return;
-        }
-        let result = self.alias.iter().position(|it| it.name == name);
-        if let Some(index) = result {
-            self.alias[index] = Alias { name, required };
-        } else {
-            self.alias.push(Alias { name, required });
-        }
+  /// reload from disk
+  pub fn reload(&mut self) {
+    let new = DvmMeta::new();
+    self.versions = new.versions;
+    self.alias = new.alias;
+  }
 
-        self.save_and_reload();
+  /// write to disk
+  pub fn save(&self) {
+    let file_path = DvmMeta::path();
+    let dir_path = file_path.parent().unwrap();
+    if !dir_path.exists() {
+      create_dir_all(dir_path).unwrap();
     }
+    write(file_path, serde_json::to_string_pretty(self).unwrap()).unwrap();
+  }
 
-    pub fn has_alias(&self, name: &str) -> bool {
-        self.get_alias(name).is_some()
-    }
-
-    /// get the semver range of alias
-    pub fn get_alias(&self, name: &str) -> Option<VersionArg> {
-        if DEFAULT_ALIAS.contains_key(name) {
-            VersionArg::from_str(DEFAULT_ALIAS[name]).ok()
-        } else {
-            self
-                .alias
-                .iter()
-                .position(|it| it.name == name)
-                .map(|index| VersionArg::from_str(&self.alias[index].required).unwrap())
-        }
-    }
-
-    /// delete a alias
-    pub fn delete_alias(&mut self, name: String) {
-        let result = self.alias.iter().position(|it| it.name == name);
-        if let Some(index) = result {
-            self.alias.remove(index);
-        }
-
-        self.save_and_reload();
-    }
-
-    pub fn resolve_version_req(&self, required: &str) -> VersionArg {
-        if self.has_alias(required) {
-            self.get_alias(required).unwrap()
-        } else {
-            VersionArg::from_str(required).unwrap()
-        }
-    }
-
-    /// reload from disk
-    pub fn reload(&mut self) {
-        let new = DvmMeta::new();
-        self.versions = new.versions;
-        self.alias = new.alias;
-    }
-
-    /// write to disk
-    pub fn save(&self) {
-        let file_path = DvmMeta::path();
-        let dir_path = file_path.parent().unwrap();
-        if !dir_path.exists() {
-            create_dir_all(dir_path).unwrap();
-        }
-        write(file_path, serde_json::to_string_pretty(self).unwrap()).unwrap();
-    }
-
-    pub fn save_and_reload(&mut self) {
-        self.save();
-        self.reload();
-    }
+  pub fn save_and_reload(&mut self) {
+    self.save();
+    self.reload();
+  }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use serde_json::json;
+  use super::*;
+  use serde_json::json;
 
-    #[test]
-    fn test_default_config() {
-        let result = serde_json::to_string(&DvmMeta::default());
-        assert!(result.is_ok());
-        assert_eq!(
-            result.unwrap(),
-            "{\"registry\":\"https://dl.deno.land/\",\"versions\":[],\"alias\":[]}"
-        );
-    }
+  #[test]
+  fn test_default_config() {
+    let result = serde_json::to_string(&DvmMeta::default());
+    assert!(result.is_ok());
+    assert_eq!(
+      result.unwrap(),
+      "{\"registry\":\"https://dl.deno.land/\",\"versions\":[],\"alias\":[]}"
+    );
+  }
 
-    #[test]
-    fn test_versions_config() {
-        let mut conf = DvmMeta::default();
-        conf.versions.push(VersionMapping {
-            required: "~1.0.0".to_string(),
-            current: "1.0.1".to_string(),
-        });
-        let result = serde_json::to_string(&conf);
-        assert!(result.is_ok());
-        assert_eq!(
+  #[test]
+  fn test_versions_config() {
+    let mut conf = DvmMeta::default();
+    conf.versions.push(VersionMapping {
+      required: "~1.0.0".to_string(),
+      current: "1.0.1".to_string(),
+    });
+    let result = serde_json::to_string(&conf);
+    assert!(result.is_ok());
+    assert_eq!(
             result.unwrap(),
             "{\"registry\":\"https://dl.deno.land/\",\"versions\":[{\"required\":\"~1.0.0\",\"current\":\"1.0.1\"}],\"alias\":[]}"
         )
-    }
+  }
 
-    #[test]
-    fn test_alias_config() {
-        let mut conf = DvmMeta::default();
-        conf.alias.push(Alias {
-            name: "stable".to_string(),
-            required: "1.0.0".to_string(),
-        });
-        conf.alias.push(Alias {
-            name: "two-point-o".to_string(),
-            required: "2.0.0".to_string(),
-        });
-        let result = serde_json::to_string(&conf);
-        assert!(result.is_ok());
-        assert_eq!(
+  #[test]
+  fn test_alias_config() {
+    let mut conf = DvmMeta::default();
+    conf.alias.push(Alias {
+      name: "stable".to_string(),
+      required: "1.0.0".to_string(),
+    });
+    conf.alias.push(Alias {
+      name: "two-point-o".to_string(),
+      required: "2.0.0".to_string(),
+    });
+    let result = serde_json::to_string(&conf);
+    assert!(result.is_ok());
+    assert_eq!(
             result.unwrap(),
             "{\"registry\":\"https://dl.deno.land/\",\"versions\":[],\"alias\":[{\"name\":\"stable\",\"required\":\"1.0.0\"},{\"name\":\"two-point-o\",\"required\":\"2.0.0\"}]}"
         )
-    }
+  }
 
-    #[test]
-    fn test_parse_valid() {
-        let raw = json!(
+  #[test]
+  fn test_parse_valid() {
+    let raw = json!(
         {
             "versions": [
                 { "required": "~1.0.0", "current": "1.0.1" },
@@ -346,24 +346,24 @@ mod tests {
         }
     );
 
-        let parsed = DvmMeta::deserialize(raw);
-        assert!(parsed.is_ok());
-        let parsed = parsed.unwrap();
-        assert_eq!(parsed.alias.len(), 2);
-        assert_eq!(parsed.versions.len(), 2);
-        assert_eq!(parsed.alias[0].name, "latest");
-        assert_eq!(parsed.alias[0].required, "*");
-        assert!(parsed.alias[0].try_to_version_req().is_ok());
-        assert_eq!(parsed.alias[1].name, "stable");
-        assert_eq!(parsed.alias[1].required, "^1.0.0");
-        assert!(parsed.alias[1].try_to_version_req().is_ok());
-        assert_eq!(parsed.versions[0].required, "~1.0.0");
-        assert_eq!(parsed.versions[0].current, "1.0.1");
-        assert!(parsed.versions[0].try_to_version_req().is_ok());
-        assert!(parsed.versions[0].is_valid_mapping());
-        assert_eq!(parsed.versions[1].required, "^1.0.0");
-        assert_eq!(parsed.versions[1].current, "1.2.0");
-        assert!(parsed.versions[1].try_to_version_req().is_ok());
-        assert!(parsed.versions[1].is_valid_mapping());
-    }
+    let parsed = DvmMeta::deserialize(raw);
+    assert!(parsed.is_ok());
+    let parsed = parsed.unwrap();
+    assert_eq!(parsed.alias.len(), 2);
+    assert_eq!(parsed.versions.len(), 2);
+    assert_eq!(parsed.alias[0].name, "latest");
+    assert_eq!(parsed.alias[0].required, "*");
+    assert!(parsed.alias[0].try_to_version_req().is_ok());
+    assert_eq!(parsed.alias[1].name, "stable");
+    assert_eq!(parsed.alias[1].required, "^1.0.0");
+    assert!(parsed.alias[1].try_to_version_req().is_ok());
+    assert_eq!(parsed.versions[0].required, "~1.0.0");
+    assert_eq!(parsed.versions[0].current, "1.0.1");
+    assert!(parsed.versions[0].try_to_version_req().is_ok());
+    assert!(parsed.versions[0].is_valid_mapping());
+    assert_eq!(parsed.versions[1].required, "^1.0.0");
+    assert_eq!(parsed.versions[1].current, "1.2.0");
+    assert!(parsed.versions[1].try_to_version_req().is_ok());
+    assert!(parsed.versions[1].is_valid_mapping());
+  }
 }

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -277,7 +277,7 @@ mod tests {
     assert!(result.is_ok());
     assert_eq!(
       result.unwrap(),
-      "{\"registry\":\"https://dl.deno.land/\",\"versions\":[],\"alias\":[]}"
+      "{\"versions\":[],\"alias\":[]}"
     );
   }
 
@@ -292,7 +292,7 @@ mod tests {
     assert!(result.is_ok());
     assert_eq!(
             result.unwrap(),
-            "{\"registry\":\"https://dl.deno.land/\",\"versions\":[{\"required\":\"~1.0.0\",\"current\":\"1.0.1\"}],\"alias\":[]}"
+            "{\"versions\":[{\"required\":\"~1.0.0\",\"current\":\"1.0.1\"}],\"alias\":[]}"
         )
   }
 
@@ -311,7 +311,7 @@ mod tests {
     assert!(result.is_ok());
     assert_eq!(
             result.unwrap(),
-            "{\"registry\":\"https://dl.deno.land/\",\"versions\":[],\"alias\":[{\"name\":\"stable\",\"required\":\"1.0.0\"},{\"name\":\"two-point-o\",\"required\":\"2.0.0\"}]}"
+            "{\"versions\":[],\"alias\":[{\"name\":\"stable\",\"required\":\"1.0.0\"},{\"name\":\"two-point-o\",\"required\":\"2.0.0\"}]}"
         )
   }
 

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -1,4 +1,4 @@
-use crate::consts::{DVM_CACHE_INVALID_TIMEOUT, REGISTRY_LIST_OFFICIAL, REGISTRY_OFFICIAL};
+use crate::consts::{DVM_CACHE_INVALID_TIMEOUT, };
 use crate::utils::{deno_version_path, dvm_root, dvm_versions, now};
 use crate::version::VersionArg;
 use colored::Colorize;
@@ -67,24 +67,8 @@ impl ToVersionReq for Alias {
   }
 }
 
-#[derive(Clone, Eq, PartialEq, Deserialize, Serialize)]
-pub struct Registry {
-  pub binary: String,
-  pub version: String,
-}
-
-impl Default for Registry {
-  fn default() -> Self {
-    Registry {
-      binary: REGISTRY_OFFICIAL.to_string(),
-      version: REGISTRY_LIST_OFFICIAL.to_string(),
-    }
-  }
-}
-
 #[derive(Clone, Default, Eq, PartialEq, Deserialize, Serialize)]
 pub struct DvmMeta {
-  pub registry: Registry,
   pub versions: Vec<VersionMapping>,
   pub alias: Vec<Alias>,
 }

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -275,10 +275,7 @@ mod tests {
   fn test_default_config() {
     let result = serde_json::to_string(&DvmMeta::default());
     assert!(result.is_ok());
-    assert_eq!(
-      result.unwrap(),
-      "{\"versions\":[],\"alias\":[]}"
-    );
+    assert_eq!(result.unwrap(), "{\"versions\":[],\"alias\":[]}");
   }
 
   #[test]
@@ -291,9 +288,9 @@ mod tests {
     let result = serde_json::to_string(&conf);
     assert!(result.is_ok());
     assert_eq!(
-            result.unwrap(),
-            "{\"versions\":[{\"required\":\"~1.0.0\",\"current\":\"1.0.1\"}],\"alias\":[]}"
-        )
+      result.unwrap(),
+      "{\"versions\":[{\"required\":\"~1.0.0\",\"current\":\"1.0.1\"}],\"alias\":[]}"
+    )
   }
 
   #[test]

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -1,4 +1,4 @@
-use crate::consts::{DVM_CACHE_INVALID_TIMEOUT, REGISTRY_OFFICIAL};
+use crate::consts::{DVM_CACHE_INVALID_TIMEOUT, REGISTRY_LIST_OFFICIAL, REGISTRY_OFFICIAL};
 use crate::utils::{deno_version_path, dvm_root, dvm_versions, now};
 use crate::version::VersionArg;
 use colored::Colorize;
@@ -13,326 +13,327 @@ pub const DEFAULT_ALIAS: phf::Map<&'static str, &'static str> = phf::phf_map! {
 };
 
 pub trait ToVersionReq {
-  fn to_version_req(&self) -> VersionReq;
-  fn try_to_version_req(&self) -> anyhow::Result<VersionReq>;
+    fn to_version_req(&self) -> VersionReq;
+    fn try_to_version_req(&self) -> anyhow::Result<VersionReq>;
 }
 
 #[derive(Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct VersionMapping {
-  pub required: String,
-  pub current: String,
+    pub required: String,
+    pub current: String,
 }
+
 impl VersionMapping {
-  pub fn is_valid_mapping(&self) -> bool {
-    let current = Version::parse(&self.current);
-    if current.is_err() {
-      return false;
-    }
-    let current = current.unwrap();
+    pub fn is_valid_mapping(&self) -> bool {
+        let current = Version::parse(&self.current);
+        if current.is_err() {
+            return false;
+        }
+        let current = current.unwrap();
 
-    let req = self.try_to_version_req();
-    if req.is_err() {
-      return false;
-    }
-    let req = req.unwrap();
+        let req = self.try_to_version_req();
+        if req.is_err() {
+            return false;
+        }
+        let req = req.unwrap();
 
-    req.matches(&current)
-  }
+        req.matches(&current)
+    }
 }
 
 impl ToVersionReq for VersionMapping {
-  fn to_version_req(&self) -> VersionReq {
-    VersionReq::from_str(&self.required).expect("VersionMapping::required is not a valid VersionReq")
-  }
+    fn to_version_req(&self) -> VersionReq {
+        VersionReq::from_str(&self.required).expect("VersionMapping::required is not a valid VersionReq")
+    }
 
-  fn try_to_version_req(&self) -> anyhow::Result<VersionReq> {
-    VersionReq::from_str(&self.required).map_err(|err| anyhow::anyhow!(err))
-  }
+    fn try_to_version_req(&self) -> anyhow::Result<VersionReq> {
+        VersionReq::from_str(&self.required).map_err(|err| anyhow::anyhow!(err))
+    }
 }
 
 #[derive(Clone, Eq, PartialEq, Deserialize, Serialize, Debug)]
 pub struct Alias {
-  pub name: String,
-  pub required: String,
+    pub name: String,
+    pub required: String,
 }
 
 impl ToVersionReq for Alias {
-  fn to_version_req(&self) -> VersionReq {
-    VersionReq::from_str(&self.required).expect("Alias::required is not a valid VersionReq")
-  }
+    fn to_version_req(&self) -> VersionReq {
+        VersionReq::from_str(&self.required).expect("Alias::required is not a valid VersionReq")
+    }
 
-  fn try_to_version_req(&self) -> anyhow::Result<VersionReq> {
-    VersionReq::from_str(&self.required).map_err(|err| anyhow::anyhow!(err))
-  }
+    fn try_to_version_req(&self) -> anyhow::Result<VersionReq> {
+        VersionReq::from_str(&self.required).map_err(|err| anyhow::anyhow!(err))
+    }
 }
 
 #[derive(Clone, Eq, PartialEq, Deserialize, Serialize)]
-pub struct DvmMeta {
-  #[serde(default = "default_registry")]
-  pub registry: String,
-  pub versions: Vec<VersionMapping>,
-  pub alias: Vec<Alias>,
+pub struct Registry {
+    pub binary: String,
+    pub version: String,
 }
 
-pub fn default_registry() -> String {
-  REGISTRY_OFFICIAL.to_string()
+impl Default for Registry {
+    fn default() -> Self {
+        Registry {
+            binary: REGISTRY_OFFICIAL.to_string(),
+            version: REGISTRY_LIST_OFFICIAL.to_string(),
+        }
+    }
+}
+
+#[derive(Clone, Default, Eq, PartialEq, Deserialize, Serialize)]
+pub struct DvmMeta {
+    pub registry: Registry,
+    pub versions: Vec<VersionMapping>,
+    pub alias: Vec<Alias>,
 }
 
 impl DvmMeta {
-  pub fn path() -> PathBuf {
-    let mut meta = dvm_root();
-    meta.push(Path::new("dvm-metadata.json"));
-    meta
-  }
+    pub fn path() -> PathBuf {
+        let mut meta = dvm_root();
+        meta.push(Path::new("dvm-metadata.json"));
+        meta
+    }
 
-  pub fn new() -> Self {
-    let path = DvmMeta::path();
-    if path.exists() {
-      let content = read_to_string(path);
-      if let Ok(content) = content {
-        let config = serde_json::from_str::<DvmMeta>(content.as_str());
-        if let Ok(mut config) = config {
-          let mut i = 0;
-          while i < config.versions.len() {
-            if !deno_version_path(&Version::parse(&config.versions[i].current).unwrap()).exists() {
-              config.versions.remove(i);
-            } else {
-              i += 1;
+    pub fn new() -> Self {
+        let path = DvmMeta::path();
+        if path.exists() {
+            let content = read_to_string(path);
+            if let Ok(content) = content {
+                let config = serde_json::from_str::<DvmMeta>(content.as_str());
+                if let Ok(mut config) = config {
+                    let mut i = 0;
+                    while i < config.versions.len() {
+                        if !deno_version_path(&Version::parse(&config.versions[i].current).unwrap()).exists() {
+                            config.versions.remove(i);
+                        } else {
+                            i += 1;
+                        }
+                    }
+                    return config;
+                }
             }
-          }
-          return config;
         }
-      }
+
+        let mut config = DvmMeta::default();
+        config.save_and_reload();
+        config
     }
 
-    let mut config = DvmMeta::default();
-    config.save_and_reload();
-    config
-  }
+    pub fn clean_files(&self) {
+        let cache_folder = dvm_versions();
+        if let Ok(dir) = cache_folder.read_dir() {
+            for entry in dir.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    let name = path.file_name().unwrap().to_str().unwrap();
 
-  pub fn clean_files(&self) {
-    let cache_folder = dvm_versions();
-    if let Ok(dir) = cache_folder.read_dir() {
-      for entry in dir.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-          let name = path.file_name().unwrap().to_str().unwrap();
+                    // it's been pointed by dvm versions
+                    if self.versions.iter().any(|it| it.current == name) {
+                        continue;
+                    }
 
-          // it's been pointed by dvm versions
-          if self.versions.iter().any(|it| it.current == name) {
-            continue;
-          }
+                    // it's not been outdated
+                    let stub = path.join(".dvmstub");
+                    if stub.exists() && stub.is_file() {
+                        let content = std::fs::read_to_string(stub).expect("read stub file failed");
+                        let content: u128 = content.parse().expect("parse stub file failed");
+                        if content > now() - DVM_CACHE_INVALID_TIMEOUT {
+                            continue;
+                        }
+                    }
 
-          // it's not been outdated
-          let stub = path.join(".dvmstub");
-          if stub.exists() && stub.is_file() {
-            let content = std::fs::read_to_string(stub).expect("read stub file failed");
-            let content: u128 = content.parse().expect("parse stub file failed");
-            if content > now() - DVM_CACHE_INVALID_TIMEOUT {
-              continue;
+                    println!("Cleaning version {}", name.bright_black());
+                    std::fs::remove_dir_all(path).unwrap();
+                }
             }
-          }
-
-          println!("Cleaning version {}", name.bright_black());
-          std::fs::remove_dir_all(path).unwrap();
         }
-      }
-    }
-  }
-
-  ///
-  /// set a version mapping
-  ///   `required` is either a semver range or a alias to a semver rage
-  ///   `current` is the current directory that the deno located in
-  pub fn set_version_mapping(&mut self, required: String, current: String) {
-    let result = self.versions.iter().position(|it| it.required == required);
-    if let Some(index) = result {
-      self.versions[index] = VersionMapping { required, current };
-    } else {
-      self.versions.push(VersionMapping { required, current });
-    }
-    self.save_and_reload();
-  }
-
-  ///
-  /// get fold name of a given mapping,
-  /// None if there haven't a deno version met the required semver range or alias that
-  /// are installed already
-  pub fn get_version_mapping(&self, required: &str) -> Option<String> {
-    self
-      .versions
-      .iter()
-      .position(|it| it.required == required)
-      .map(|index| self.versions[index].current.clone())
-  }
-
-  ///
-  /// delete a version mapping
-  /// this will also delete actual files.
-  pub fn delete_version_mapping(&mut self, required: String) {
-    let result = self.versions.iter().position(|it| it.required == required);
-    if let Some(index) = result {
-      self.versions.remove(index);
     }
 
-    self.save_and_reload();
-  }
-
-  ///
-  /// list aliases
-  /// including predefined aliases
-  pub fn list_alias(&self) -> Vec<Alias> {
-    let mut alias = self.alias.clone();
-    for (k, v) in DEFAULT_ALIAS.into_iter() {
-      alias.insert(
-        0,
-        Alias {
-          name: k.to_string(),
-          required: v.to_string(),
-        },
-      );
+    ///
+    /// set a version mapping
+    ///   `required` is either a semver range or a alias to a semver rage
+    ///   `current` is the current directory that the deno located in
+    pub fn set_version_mapping(&mut self, required: String, current: String) {
+        let result = self.versions.iter().position(|it| it.required == required);
+        if let Some(index) = result {
+            self.versions[index] = VersionMapping { required, current };
+        } else {
+            self.versions.push(VersionMapping { required, current });
+        }
+        self.save_and_reload();
     }
 
-    alias
-  }
-
-  /// set a alias
-  ///   name is alias name
-  ///   required is a semver range
-  pub fn set_alias(&mut self, name: String, required: String) {
-    if DEFAULT_ALIAS.contains_key(name.as_str()) {
-      return;
-    }
-    let result = self.alias.iter().position(|it| it.name == name);
-    if let Some(index) = result {
-      self.alias[index] = Alias { name, required };
-    } else {
-      self.alias.push(Alias { name, required });
+    ///
+    /// get fold name of a given mapping,
+    /// None if there haven't a deno version met the required semver range or alias that
+    /// are installed already
+    pub fn get_version_mapping(&self, required: &str) -> Option<String> {
+        self
+            .versions
+            .iter()
+            .position(|it| it.required == required)
+            .map(|index| self.versions[index].current.clone())
     }
 
-    self.save_and_reload();
-  }
+    ///
+    /// delete a version mapping
+    /// this will also delete actual files.
+    pub fn delete_version_mapping(&mut self, required: String) {
+        let result = self.versions.iter().position(|it| it.required == required);
+        if let Some(index) = result {
+            self.versions.remove(index);
+        }
 
-  pub fn has_alias(&self, name: &str) -> bool {
-    self.get_alias(name).is_some()
-  }
-
-  /// get the semver range of alias
-  pub fn get_alias(&self, name: &str) -> Option<VersionArg> {
-    if DEFAULT_ALIAS.contains_key(name) {
-      VersionArg::from_str(DEFAULT_ALIAS[name]).ok()
-    } else {
-      self
-        .alias
-        .iter()
-        .position(|it| it.name == name)
-        .map(|index| VersionArg::from_str(&self.alias[index].required).unwrap())
-    }
-  }
-
-  /// delete a alias
-  pub fn delete_alias(&mut self, name: String) {
-    let result = self.alias.iter().position(|it| it.name == name);
-    if let Some(index) = result {
-      self.alias.remove(index);
+        self.save_and_reload();
     }
 
-    self.save_and_reload();
-  }
+    ///
+    /// list aliases
+    /// including predefined aliases
+    pub fn list_alias(&self) -> Vec<Alias> {
+        let mut alias = self.alias.clone();
+        for (k, v) in DEFAULT_ALIAS.into_iter() {
+            alias.insert(
+                0,
+                Alias {
+                    name: k.to_string(),
+                    required: v.to_string(),
+                },
+            );
+        }
 
-  pub fn resolve_version_req(&self, required: &str) -> VersionArg {
-    if self.has_alias(required) {
-      self.get_alias(required).unwrap()
-    } else {
-      VersionArg::from_str(required).unwrap()
+        alias
     }
-  }
 
-  /// reload from disk
-  pub fn reload(&mut self) {
-    let new = DvmMeta::new();
-    self.versions = new.versions;
-    self.alias = new.alias;
-  }
+    /// set a alias
+    ///   name is alias name
+    ///   required is a semver range
+    pub fn set_alias(&mut self, name: String, required: String) {
+        if DEFAULT_ALIAS.contains_key(name.as_str()) {
+            return;
+        }
+        let result = self.alias.iter().position(|it| it.name == name);
+        if let Some(index) = result {
+            self.alias[index] = Alias { name, required };
+        } else {
+            self.alias.push(Alias { name, required });
+        }
 
-  /// write to disk
-  pub fn save(&self) {
-    let file_path = DvmMeta::path();
-    let dir_path = file_path.parent().unwrap();
-    if !dir_path.exists() {
-      create_dir_all(dir_path).unwrap();
+        self.save_and_reload();
     }
-    write(file_path, serde_json::to_string_pretty(self).unwrap()).unwrap();
-  }
 
-  pub fn save_and_reload(&mut self) {
-    self.save();
-    self.reload();
-  }
-}
-
-impl Default for DvmMeta {
-  fn default() -> Self {
-    Self {
-      registry: REGISTRY_OFFICIAL.to_string(),
-      versions: vec![],
-      alias: vec![],
+    pub fn has_alias(&self, name: &str) -> bool {
+        self.get_alias(name).is_some()
     }
-  }
+
+    /// get the semver range of alias
+    pub fn get_alias(&self, name: &str) -> Option<VersionArg> {
+        if DEFAULT_ALIAS.contains_key(name) {
+            VersionArg::from_str(DEFAULT_ALIAS[name]).ok()
+        } else {
+            self
+                .alias
+                .iter()
+                .position(|it| it.name == name)
+                .map(|index| VersionArg::from_str(&self.alias[index].required).unwrap())
+        }
+    }
+
+    /// delete a alias
+    pub fn delete_alias(&mut self, name: String) {
+        let result = self.alias.iter().position(|it| it.name == name);
+        if let Some(index) = result {
+            self.alias.remove(index);
+        }
+
+        self.save_and_reload();
+    }
+
+    pub fn resolve_version_req(&self, required: &str) -> VersionArg {
+        if self.has_alias(required) {
+            self.get_alias(required).unwrap()
+        } else {
+            VersionArg::from_str(required).unwrap()
+        }
+    }
+
+    /// reload from disk
+    pub fn reload(&mut self) {
+        let new = DvmMeta::new();
+        self.versions = new.versions;
+        self.alias = new.alias;
+    }
+
+    /// write to disk
+    pub fn save(&self) {
+        let file_path = DvmMeta::path();
+        let dir_path = file_path.parent().unwrap();
+        if !dir_path.exists() {
+            create_dir_all(dir_path).unwrap();
+        }
+        write(file_path, serde_json::to_string_pretty(self).unwrap()).unwrap();
+    }
+
+    pub fn save_and_reload(&mut self) {
+        self.save();
+        self.reload();
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  use super::*;
-  use serde_json::json;
+    use super::*;
+    use serde_json::json;
 
-  #[test]
-  fn test_default_config() {
-    let result = serde_json::to_string(&DvmMeta::default());
-    assert!(result.is_ok());
-    assert_eq!(
-      result.unwrap(),
-      "{\"registry\":\"https://dl.deno.land/\",\"versions\":[],\"alias\":[]}"
-    );
-  }
+    #[test]
+    fn test_default_config() {
+        let result = serde_json::to_string(&DvmMeta::default());
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            "{\"registry\":\"https://dl.deno.land/\",\"versions\":[],\"alias\":[]}"
+        );
+    }
 
-  #[test]
-  fn test_versions_config() {
-    let mut conf = DvmMeta::default();
-    conf.versions.push(VersionMapping {
-      required: "~1.0.0".to_string(),
-      current: "1.0.1".to_string(),
-    });
-    let result = serde_json::to_string(&conf);
-    assert!(result.is_ok());
-    assert_eq!(
-      result.unwrap(),
-      "{\"registry\":\"https://dl.deno.land/\",\"versions\":[{\"required\":\"~1.0.0\",\"current\":\"1.0.1\"}],\"alias\":[]}"
-    )
-  }
+    #[test]
+    fn test_versions_config() {
+        let mut conf = DvmMeta::default();
+        conf.versions.push(VersionMapping {
+            required: "~1.0.0".to_string(),
+            current: "1.0.1".to_string(),
+        });
+        let result = serde_json::to_string(&conf);
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            "{\"registry\":\"https://dl.deno.land/\",\"versions\":[{\"required\":\"~1.0.0\",\"current\":\"1.0.1\"}],\"alias\":[]}"
+        )
+    }
 
-  #[test]
-  fn test_alias_config() {
-    let mut conf = DvmMeta::default();
-    conf.alias.push(Alias {
-      name: "stable".to_string(),
-      required: "1.0.0".to_string(),
-    });
-    conf.alias.push(Alias {
-      name: "two-point-o".to_string(),
-      required: "2.0.0".to_string(),
-    });
-    let result = serde_json::to_string(&conf);
-    assert!(result.is_ok());
-    assert_eq!(
+    #[test]
+    fn test_alias_config() {
+        let mut conf = DvmMeta::default();
+        conf.alias.push(Alias {
+            name: "stable".to_string(),
+            required: "1.0.0".to_string(),
+        });
+        conf.alias.push(Alias {
+            name: "two-point-o".to_string(),
+            required: "2.0.0".to_string(),
+        });
+        let result = serde_json::to_string(&conf);
+        assert!(result.is_ok());
+        assert_eq!(
             result.unwrap(),
             "{\"registry\":\"https://dl.deno.land/\",\"versions\":[],\"alias\":[{\"name\":\"stable\",\"required\":\"1.0.0\"},{\"name\":\"two-point-o\",\"required\":\"2.0.0\"}]}"
         )
-  }
+    }
 
-  #[test]
-  fn test_parse_valid() {
-    let raw = json!(
+    #[test]
+    fn test_parse_valid() {
+        let raw = json!(
         {
             "versions": [
                 { "required": "~1.0.0", "current": "1.0.1" },
@@ -345,24 +346,24 @@ mod tests {
         }
     );
 
-    let parsed = DvmMeta::deserialize(raw);
-    assert!(parsed.is_ok());
-    let parsed = parsed.unwrap();
-    assert_eq!(parsed.alias.len(), 2);
-    assert_eq!(parsed.versions.len(), 2);
-    assert_eq!(parsed.alias[0].name, "latest");
-    assert_eq!(parsed.alias[0].required, "*");
-    assert!(parsed.alias[0].try_to_version_req().is_ok());
-    assert_eq!(parsed.alias[1].name, "stable");
-    assert_eq!(parsed.alias[1].required, "^1.0.0");
-    assert!(parsed.alias[1].try_to_version_req().is_ok());
-    assert_eq!(parsed.versions[0].required, "~1.0.0");
-    assert_eq!(parsed.versions[0].current, "1.0.1");
-    assert!(parsed.versions[0].try_to_version_req().is_ok());
-    assert!(parsed.versions[0].is_valid_mapping());
-    assert_eq!(parsed.versions[1].required, "^1.0.0");
-    assert_eq!(parsed.versions[1].current, "1.2.0");
-    assert!(parsed.versions[1].try_to_version_req().is_ok());
-    assert!(parsed.versions[1].is_valid_mapping());
-  }
+        let parsed = DvmMeta::deserialize(raw);
+        assert!(parsed.is_ok());
+        let parsed = parsed.unwrap();
+        assert_eq!(parsed.alias.len(), 2);
+        assert_eq!(parsed.versions.len(), 2);
+        assert_eq!(parsed.alias[0].name, "latest");
+        assert_eq!(parsed.alias[0].required, "*");
+        assert!(parsed.alias[0].try_to_version_req().is_ok());
+        assert_eq!(parsed.alias[1].name, "stable");
+        assert_eq!(parsed.alias[1].required, "^1.0.0");
+        assert!(parsed.alias[1].try_to_version_req().is_ok());
+        assert_eq!(parsed.versions[0].required, "~1.0.0");
+        assert_eq!(parsed.versions[0].current, "1.0.1");
+        assert!(parsed.versions[0].try_to_version_req().is_ok());
+        assert!(parsed.versions[0].is_valid_mapping());
+        assert_eq!(parsed.versions[1].required, "^1.0.0");
+        assert_eq!(parsed.versions[1].current, "1.2.0");
+        assert!(parsed.versions[1].try_to_version_req().is_ok());
+        assert!(parsed.versions[1].is_valid_mapping());
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -129,7 +129,6 @@ pub fn is_http_like_url(url: &str) -> bool {
   url.starts_with("http://") || url.starts_with("https://")
 }
 
-
 #[cfg(test)]
 mod tests {
   use super::*;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,3 @@
-use cfg_if::cfg_if;
-
 use crate::consts::{DENO_EXE, DVM_CACHE_PATH_PREFIX, DVM_CANARY_PATH_PREFIX};
 use crate::version::VersionArg;
 use anyhow::anyhow;
@@ -126,31 +124,11 @@ pub fn is_semver(version: &str) -> bool {
   Version::parse(version).is_ok()
 }
 
-cfg_if! {
-  if #[cfg(windows)] {
-    pub fn is_china_mainland() -> bool {
-      use winapi::ctypes::c_int;
-      use winapi::um::winnls::GetUserDefaultLocaleName;
-
-      // The maximum number of characters allowed for this string is 85,
-      // including a terminating null character.
-      // https://docs.microsoft.com/en-us/windows/win32/intl/locale-sname
-      let mut buf = [0u16; 85];
-      // SAFETY: Call `winapi` raw binding to win32 api.
-      let len = unsafe { GetUserDefaultLocaleName(buf.as_mut_ptr(), buf.len() as c_int) };
-
-      if len <= 0 {
-        return false;
-      }
-
-      String::from_utf16_lossy(&buf).starts_with("zh-CN")
-    }
-  } else {
-    pub fn is_china_mainland() -> bool {
-      env::var("LANG").map(|lng| lng.starts_with("zh_CN.")).unwrap_or(false)
-    }
-  }
+#[inline]
+pub fn is_http_like_url(url: &str) -> bool {
+  url.starts_with("http://") || url.starts_with("https://")
 }
+
 
 #[cfg(test)]
 mod tests {

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,9 +1,9 @@
 // Copyright 2022 justjavac. All rights reserved. MIT license.
 use crate::consts::{
-  DVM_CACHE_PATH_PREFIX, DVM_CACHE_REMOTE_PATH, DVM_CHINA_MAINLAND_REGISTRY, DVM_INTERNATIONAL_REGISTRY,
-  REGISTRY_LATEST_CANARY_PATH, REGISTRY_LATEST_RELEASE_PATH,
+  DVM_CACHE_PATH_PREFIX, DVM_CACHE_REMOTE_PATH, REGISTRY_LATEST_CANARY_PATH, REGISTRY_LATEST_RELEASE_PATH,
+  REGISTRY_LIST_CN, REGISTRY_LIST_OFFICIAL,
 };
-use crate::utils::{dvm_root, is_china_mainland, is_exact_version, is_semver};
+use crate::utils::{dvm_root, is_exact_version, is_semver};
 use anyhow::Result;
 use chrono::{DateTime, Local};
 use json_minimal::Json;
@@ -19,6 +19,7 @@ use std::string::String;
 
 pub const DVM: &str = env!("CARGO_PKG_VERSION");
 const CACHE_DURATION: i32 = 60 * 60 * 24;
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Cached {
   versions: Vec<String>,
@@ -98,16 +99,16 @@ fn cached_versions() -> Option<Vec<String>> {
   let content = read_to_string(dvm_root().join(Path::new(DVM_CACHE_REMOTE_PATH)));
 
   let Ok(content) = content else {
-    return None;
-  };
+        return None;
+    };
   let cached = from_str::<Cached>(content.as_str());
   let Ok(cached) = cached else {
-    return None;
-  };
+        return None;
+    };
   let cache_time: Result<DateTime<Local>, _> = DateTime::from_str(cached.time.as_str());
   let Ok(cache_time) = cache_time else {
-    return None;
-  };
+        return None;
+    };
   let expired = (Local::now().timestamp() - cache_time.timestamp()) > CACHE_DURATION as i64;
   if expired || cached.versions.is_empty() {
     return None;
@@ -127,8 +128,8 @@ fn cache_remote_versions(versions: &[String]) {
 }
 
 pub fn remote_versions() -> Result<Vec<String>> {
-  if is_china_mainland() {
-    let response = tinyget::get(DVM_CHINA_MAINLAND_REGISTRY).send()?;
+  if false {
+    let response = tinyget::get(REGISTRY_LIST_CN).send()?;
     let body = response.as_str()?;
     let json = Json::parse(body.as_bytes()).unwrap();
     let mut result: Vec<String> = Vec::new();
@@ -146,7 +147,7 @@ pub fn remote_versions() -> Result<Vec<String>> {
     return Ok(result);
   }
 
-  let response = tinyget::get(DVM_INTERNATIONAL_REGISTRY)
+  let response = tinyget::get(REGISTRY_LIST_OFFICIAL)
     .with_header("User-Agent", "tinyget") // http://developer.github.com/v3/#user-agent-required
     .send()?;
   let body = response.as_str()?;

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,24 +1,22 @@
 // Copyright 2022 justjavac. All rights reserved. MIT license.
+use crate::configrc::rc_get;
 use crate::consts::{
-  DVM_CACHE_PATH_PREFIX, DVM_CACHE_REMOTE_PATH, REGISTRY_LATEST_CANARY_PATH, REGISTRY_LATEST_RELEASE_PATH,
-  REGISTRY_LIST_CN, REGISTRY_LIST_OFFICIAL,
+  DVM_CACHE_PATH_PREFIX, DVM_CONFIGRC_KEY_REGISTRY_VERSION, REGISTRY_LATEST_CANARY_PATH, REGISTRY_LATEST_RELEASE_PATH,
+  REGISTRY_LIST_OFFICIAL,
 };
 use crate::utils::{dvm_root, is_exact_version, is_semver};
 use anyhow::Result;
-use chrono::{DateTime, Local};
 use json_minimal::Json;
 use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
-use serde_json::from_str;
 use std::fmt::Formatter;
-use std::fs::{read_dir, read_to_string, write};
+use std::fs::read_dir;
 use std::path::Path;
 use std::process::{Command, Stdio};
 use std::str::FromStr;
 use std::string::String;
 
 pub const DVM: &str = env!("CARGO_PKG_VERSION");
-const CACHE_DURATION: i32 = 60 * 60 * 24;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Cached {
@@ -87,83 +85,22 @@ pub fn local_versions() -> Vec<String> {
   v
 }
 
-pub fn remote_versions_or_cached() -> Result<Vec<String>> {
-  let versions = cached_versions();
-  if let Some(versions) = versions {
-    return Ok(versions);
-  }
-  remote_versions()
-}
-
-fn cached_versions() -> Option<Vec<String>> {
-  let content = read_to_string(dvm_root().join(Path::new(DVM_CACHE_REMOTE_PATH)));
-
-  let Ok(content) = content else {
-        return None;
-    };
-  let cached = from_str::<Cached>(content.as_str());
-  let Ok(cached) = cached else {
-        return None;
-    };
-  let cache_time: Result<DateTime<Local>, _> = DateTime::from_str(cached.time.as_str());
-  let Ok(cache_time) = cache_time else {
-        return None;
-    };
-  let expired = (Local::now().timestamp() - cache_time.timestamp()) > CACHE_DURATION as i64;
-  if expired || cached.versions.is_empty() {
-    return None;
-  }
-  Some(cached.versions)
-}
-
-fn cache_remote_versions(versions: &[String]) {
-  let cached = Cached {
-    versions: versions.to_owned(),
-    time: Local::now().to_string(),
-  };
-  let _ = write(
-    dvm_root().join(Path::new(DVM_CACHE_REMOTE_PATH)),
-    serde_json::to_string(&cached).unwrap(),
-  );
-}
-
 pub fn remote_versions() -> Result<Vec<String>> {
-  if false {
-    let response = tinyget::get(REGISTRY_LIST_CN).send()?;
-    let body = response.as_str()?;
-    let json = Json::parse(body.as_bytes()).unwrap();
-    let mut result: Vec<String> = Vec::new();
-
-    if let Json::OBJECT { name: _, value } = json.get("cli").unwrap() {
-      if let Json::ARRAY(list) = value.unbox() {
-        for item in list {
-          if let Json::STRING(val) = item.unbox() {
-            result.push(val.replace('v', "").to_string());
-          }
-        }
-      }
-    }
-    cache_remote_versions(&result);
-    return Ok(result);
-  }
-
-  let response = tinyget::get(REGISTRY_LIST_OFFICIAL)
-    .with_header("User-Agent", "tinyget") // http://developer.github.com/v3/#user-agent-required
-    .send()?;
+  let url = rc_get(DVM_CONFIGRC_KEY_REGISTRY_VERSION).unwrap_or_else(|_| REGISTRY_LIST_OFFICIAL.to_string());
+  let response = tinyget::get(url).send()?;
   let body = response.as_str()?;
   let json = Json::parse(body.as_bytes()).unwrap();
   let mut result: Vec<String> = Vec::new();
 
-  if let Json::ARRAY(list) = json {
-    for item in &list {
-      if let Json::OBJECT { name: _, value } = item.get("name").unwrap() {
-        if let Json::STRING(val) = value.unbox() {
+  if let Json::OBJECT { name: _, value } = json.get("cli").unwrap() {
+    if let Json::ARRAY(list) = value.unbox() {
+      for item in list {
+        if let Json::STRING(val) = item.unbox() {
           result.push(val.replace('v', "").to_string());
         }
       }
     }
   }
-  cache_remote_versions(&result);
   Ok(result)
 }
 


### PR DESCRIPTION
* registry command refactor
* internal refactor about how registry was stored
* add `--write-local` or `-L` flags to `use` command and `registry set`
* remove registry autochange by auto detect user's locale language
* unify `version registry` format (different between `official` and `cn` before)
* and more

#### .dvmrc example
```rc
registry_binary=https://dl.deno.land/
registry_version=https://raw.githubusercontent.com/denoland/dotland/main/versions.json
deno_version=latest
```

#### command screenshot
![image](https://user-images.githubusercontent.com/15936231/202129869-2605a78b-7c6d-4c46-841b-e158c86589aa.png)