### PR TITLE
Fix PowerShell installation issues

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -27,7 +27,7 @@ curl.exe -Lo $DvmZip $DvmUri
 # Remove the old dvm.exe.old if it exists
 Remove-Item $DvmExeOld -ErrorAction SilentlyContinue
 # You cant delete a file that is currently running, so rename it
-Rename-Item -Path $DvmExe -NewName $DvmExeOldName
+Rename-Item -Path $DvmExe -NewName $DvmExeOldName -ErrorAction SilentlyContinue
 
 tar.exe xf $DvmZip -C $BinDir
 

--- a/main.ts
+++ b/main.ts
@@ -3,7 +3,7 @@ import { serve } from "https://deno.land/std@0.152.0/http/server.ts";
 serve(async (req: Request) => {
   const userAgent = req.headers.get("User-Agent") || "";
 
-  if (userAgent.includes("WindowsPowerShell")) {
+  if (userAgent.includes("PowerShell")) {
     return new Response(await Deno.readFile("./install.ps1"));
   }
 


### PR DESCRIPTION
- Add `-ErrorAction SilentlyContinue` to `Rename-Item` to avoid first-time installation failures.
- Update to reflect changes in PowerShell user agent since PowerShell 6
    - https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/invoke-restmethod?view=powershell-7.3#-useragent