### PR TITLE
ensure leading newline when adding lines to shell profile

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -53,8 +53,9 @@ case $SHELL in
 esac
 
 if [ ! $DVM_DIR ];then
-    command echo "export DVM_DIR=\"$dvm_dir\"" >> "$HOME/$shell_profile"
-    command echo "export PATH=\"\$DVM_DIR/bin:\$PATH\"" >> "$HOME/$shell_profile"
+	EXPORT_DVM_DIR="export DVM_DIR=\"$dvm_dir\""
+	EXPORT_PATH="export PATH=\"\$DVM_DIR/bin:\$PATH\""
+	command printf "\\n$EXPORT_DVM_DIR\\n$EXPORT_PATH\\n" >> "$HOME/$shell_profile"
 fi
 
 echo "Dvm was installed successfully to $exe"


### PR DESCRIPTION
The install script currently breaks `.bash_profile` if it doesn't end with a trailing newline.

For example:
```
ulimit -n 8192
```

becomes
```
ulimit -n 8192export DVM_DIR="..."
```