### PR TITLE
fix: local .dvmrc not read when global exists

### DIFF
--- a/src/configrc.rs
+++ b/src/configrc.rs
@@ -160,7 +160,7 @@ fn rc_content(is_local: bool) -> (std::path::PathBuf, io::Result<String>) {
 }
 
 fn rc_content_cascade() -> io::Result<String> {
-  rc_content(false).1.or_else(|_| rc_content(true).1)
+  rc_content(true).1.or_else(|_| rc_content(false).1)
 }
 
 /// remove all key value pair that ain't supported by dvm from config file


### PR DESCRIPTION
## Summary

`rc_content_cascade()` checks global `~/.dvmrc` before local `./.dvmrc`, which is the opposite of the documented behavior. This means `dvm use --write-local <version>` has no effect when a global config exists.

The bug is compounded by `rc_fix()` (added in #195) which auto-populates `deno_version=latest` in the global file whenever the key is missing, permanently shadowing any local override.

**Fix:** swap the order in `rc_content_cascade` so local is checked first, falling back to global — matching the comment on `rc_get`: *"first try to get from current folder, if not found, try to get from home folder"*.

## Root cause

```rust
// Before (broken): global first, local fallback
fn rc_content_cascade() -> io::Result<String> {
  rc_content(false).1.or_else(|_| rc_content(true).1)
}

// After (fixed): local first, global fallback
fn rc_content_cascade() -> io::Result<String> {
  rc_content(true).1.or_else(|_| rc_content(false).1)
}
```

## Known limitation

`rc_content_cascade` returns the entire content of whichever file it finds first — it doesn't merge keys across local and global files. This means if a local `.dvmrc` exists with only `deno_version=2.6.9`, keys like `registry_binary` from the global file won't be found via the cascade.

In practice this isn't a problem today because:
- Local `.dvmrc` files only contain `deno_version` (written by `dvm use --write-local`)
- Registry keys only live in the global file
- `rc_get_with_fix` calls `rc_fix()` on miss, which populates missing keys in the global file

But the underlying design (per-file cascade instead of per-key lookup) is fragile. A proper fix would check each file for the requested key individually. That's a separate concern from this PR.

Fixes #213