### PR TITLE
fix: support registry shortcuts

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -180,6 +180,26 @@ pub enum RegistryCommands {
   #[clap(about = "Show current binary registry and version registry")]
   Show,
 
+  #[clap(name = "official", about = "Set registry to official registry")]
+  Official {
+    #[clap(
+      long = "write-local",
+      short = 'L',
+      help = "Write to current directory .dvmrc file instead of global(user-wide) config"
+    )]
+    write_local: bool,
+  },
+
+  #[clap(name = "cn", about = "Set registry to cn registry")]
+  Cn {
+    #[clap(
+      long = "write-local",
+      short = 'L',
+      help = "Write to current directory .dvmrc file instead of global(user-wide) config"
+    )]
+    write_local: bool,
+  },
+
   #[clap(about = "Set registry to one of predefined registries")]
   Set {
     predefined: RegistryPredefined,
@@ -281,5 +301,29 @@ impl RegistryPredefined {
       RegistryPredefined::CN => REGISTRY_CN,
     }
     .to_string()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn parses_registry_predefined_shortcuts() {
+    let cli = Cli::try_parse_from(["dvm", "registry", "cn"]).unwrap();
+    match cli.command {
+      Commands::Registry {
+        command: RegistryCommands::Cn { write_local },
+      } => assert!(!write_local),
+      _ => panic!("expected registry cn shortcut"),
+    }
+
+    let cli = Cli::try_parse_from(["dvm", "registry", "official", "--write-local"]).unwrap();
+    match cli.command {
+      Commands::Registry {
+        command: RegistryCommands::Official { write_local },
+      } => assert!(write_local),
+      _ => panic!("expected registry official shortcut"),
+    }
   }
 }

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -35,6 +35,14 @@ pub fn exec(meta: &mut DvmMeta, registry: RegistryCommands) -> Result<()> {
       println!("  binary_registry\t{}", rc_binary_registry);
       println!("  version_registry\t{}", rc_version_registry);
     }
+    RegistryCommands::Official { write_local } => {
+      rc_update(write_local, DVM_CONFIGRC_KEY_REGISTRY_BINARY, REGISTRY_OFFICIAL)?;
+      rc_update(write_local, DVM_CONFIGRC_KEY_REGISTRY_VERSION, REGISTRY_LIST_OFFICIAL)?;
+    }
+    RegistryCommands::Cn { write_local } => {
+      rc_update(write_local, DVM_CONFIGRC_KEY_REGISTRY_BINARY, REGISTRY_CN)?;
+      rc_update(write_local, DVM_CONFIGRC_KEY_REGISTRY_VERSION, REGISTRY_LIST_CN)?;
+    }
     RegistryCommands::Set {
       predefined,
       write_local,


### PR DESCRIPTION
## Summary
- Add direct registry shortcuts for `dvm registry cn` and `dvm registry official`
- Keep behavior aligned with existing `dvm registry set <name>` command
- Add parser coverage for the shortcut forms

Fixes #226

## Tests
- `cargo test`
- `cargo run --quiet -- registry cn` with temporary HOME/USERPROFILE, then `registry show`