### PR TITLE
fix: install dvm from release assets

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@ else
 	esac
 fi
 
-dvm_uri="https://cdn.jsdelivr.net/gh/justjavac/dvm_releases@main/dvm-${target}.zip"
+dvm_uri="https://github.com/justjavac/dvm/releases/latest/download/dvm-${target}.zip"
 
 dvm_dir="${DVM_DIR:-$HOME/.dvm}"
 dvm_bin_dir="$dvm_dir/bin"


### PR DESCRIPTION
## Summary
- Download installer artifacts from GitHub Releases `latest/download` instead of `justjavac/dvm_releases@main`
- Avoid the current `dvm-x86_64-apple-darwin.zip` artifact in `dvm_releases@main`, which contains an arm64 Mach-O binary

Fixes #225

## Tests
- `bash -n install.sh`
- Downloaded `dvm-x86_64-apple-darwin.zip` from the new URL and verified Mach-O cputype `0x01000007`
- Downloaded `dvm-aarch64-apple-darwin.zip` from the new URL and verified Mach-O cputype `0x0100000c`