### PR TITLE
fix: distinguish latest and lts versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,10 @@ Options:
 EXAMPLE:
   dvm install 1.3.2     Install v1.3.2 release
   dvm install           Install the latest available version
+  dvm install lts       Install the latest LTS version
   dvm use 1.0.0         Use v1.0.0 release
   dvm use latest        Use the latest alias that comes with dvm, equivalent to *
+  dvm use lts           Use the latest LTS version
   dvm use canary        Use the canary version of the Deno
 
 NOTE:

--- a/README_zh-cn.md
+++ b/README_zh-cn.md
@@ -54,8 +54,10 @@ Options:
 EXAMPLE:
   dvm install 1.3.2     Install v1.3.2 release
   dvm install           Install the latest available version
+  dvm install lts       Install the latest LTS version
   dvm use 1.0.0         Use v1.0.0 release
   dvm use latest        Use the latest alias that comes with dvm, equivalent to *
+  dvm use lts           Use the latest LTS version
   dvm use canary        Use the canary version of the Deno
 
 NOTE:

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -1,10 +1,10 @@
 use std::process::Stdio;
 
 use crate::{
-  consts::DVM_VERSION_LATEST,
+  consts::{DVM_VERSION_LATEST, DVM_VERSION_LTS},
   meta::DvmMeta,
   utils::{best_version, deno_version_path, is_exact_version, prompt_request},
-  version::{remote_versions, VersionArg},
+  version::{get_latest_lts_version, remote_versions, VersionArg},
 };
 use anyhow::Result;
 use colored::Colorize;
@@ -17,23 +17,34 @@ pub fn exec(meta: &mut DvmMeta, version: Option<String>, args: Vec<String>) -> R
   let version = version.unwrap_or_else(|| DVM_VERSION_LATEST.to_string());
   let v = version.clone();
 
-  let Some(version) = is_exact_version(&version).then_some(version).or_else(|| {
-    meta.has_alias(&v).then(|| {
-      let version_req = meta.resolve_version_req(&v);
-      match version_req {
-        VersionArg::Exact(v) => v.to_string(),
-        VersionArg::Range(r) => {
-          let best = best_version(versions.iter().map(AsRef::as_ref), r.clone());
-          if let Some(best) = best {
-            best.to_string()
-          } else {
-            eprintln!("No version found for {} in {:?}", r, versions);
-            std::process::exit(1);
-          }
+  let version = if is_exact_version(&version) {
+    version
+  } else if version == DVM_VERSION_LTS {
+    println!("Checking for latest LTS version");
+    let version = get_latest_lts_version()?;
+    println!("The latest LTS version is v{}", version);
+    version.to_string()
+  } else if meta.has_alias(&v) {
+    let version_req = meta.resolve_version_req(&v);
+    match version_req {
+      VersionArg::Exact(v) => v.to_string(),
+      VersionArg::Lts => {
+        println!("Checking for latest LTS version");
+        let version = get_latest_lts_version()?;
+        println!("The latest LTS version is v{}", version);
+        version.to_string()
+      }
+      VersionArg::Range(r) => {
+        let best = best_version(versions.iter().map(AsRef::as_ref), r.clone());
+        if let Some(best) = best {
+          best.to_string()
+        } else {
+          eprintln!("No version found for {} in {:?}", r, versions);
+          std::process::exit(1);
         }
       }
-    })
-  }) else {
+    }
+  } else {
     eprintln!("{}", "No such alias or version found.".red());
     std::process::exit(1);
   };

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -3,12 +3,12 @@
 use super::use_version;
 use crate::configrc::rc_get_with_fix;
 use crate::consts::{
-  DVM_CACHE_PATH_PREFIX, DVM_CANARY_PATH_PREFIX, DVM_CONFIGRC_KEY_REGISTRY_BINARY, DVM_VERSION_CANARY,
-  DVM_VERSION_LATEST, REGISTRY_OFFICIAL,
+  DVM_CACHE_PATH_PREFIX, DVM_CANARY_PATH_PREFIX, DVM_CONFIGRC_KEY_REGISTRY_BINARY, DVM_CONFIGRC_KEY_REGISTRY_VERSION,
+  DVM_VERSION_CANARY, DVM_VERSION_LATEST, DVM_VERSION_LTS, REGISTRY_LIST_OFFICIAL, REGISTRY_OFFICIAL,
 };
 use crate::meta::DvmMeta;
 use crate::utils::{deno_canary_path, deno_version_path, dvm_root};
-use crate::version::get_latest_canary;
+use crate::version::{get_latest_canary, get_latest_lts_version, get_latest_remote_version};
 use anyhow::Result;
 use cfg_if::cfg_if;
 use semver::Version;
@@ -34,6 +34,8 @@ cfg_if! {
 pub fn exec(_: &DvmMeta, no_use: bool, version: Option<String>) -> Result<()> {
   let binary_registry_url =
     rc_get_with_fix(DVM_CONFIGRC_KEY_REGISTRY_BINARY).unwrap_or_else(|_| REGISTRY_OFFICIAL.to_string());
+  let version_registry_url =
+    rc_get_with_fix(DVM_CONFIGRC_KEY_REGISTRY_VERSION).unwrap_or_else(|_| REGISTRY_LIST_OFFICIAL.to_string());
 
   if let Some(version) = version.clone() {
     if version == *DVM_VERSION_CANARY {
@@ -52,10 +54,27 @@ pub fn exec(_: &DvmMeta, no_use: bool, version: Option<String>) -> Result<()> {
   }
 
   let install_version = match version {
+    Some(ref passed_version) if passed_version == DVM_VERSION_LATEST => {
+      println!("Checking for latest version");
+      let version = get_latest_remote_version(&version_registry_url)?;
+      println!("The latest version is v{}", version);
+      version
+    }
+    Some(ref passed_version) if passed_version == DVM_VERSION_LTS => {
+      println!("Checking for latest LTS version");
+      let version = get_latest_lts_version()?;
+      println!("The latest LTS version is v{}", version);
+      version
+    }
     Some(ref passed_version) => {
       Version::parse(passed_version).map_err(|_| anyhow::format_err!("Invalid semver {}", passed_version))?
     }
-    None => get_latest_version(&binary_registry_url)?,
+    None => {
+      println!("Checking for latest version");
+      let version = get_latest_remote_version(&version_registry_url)?;
+      println!("The latest version is v{}", version);
+      version
+    }
   };
 
   let exe_path = deno_version_path(&install_version);
@@ -80,17 +99,6 @@ pub fn exec(_: &DvmMeta, no_use: bool, version: Option<String>) -> Result<()> {
   }
 
   Ok(())
-}
-
-fn get_latest_version(registry: &str) -> Result<Version> {
-  println!("Checking for latest version");
-
-  let response = tinyget::get(format!("{}release-latest.txt", registry)).send()?;
-
-  let body = response.as_str()?;
-  let v = body.trim().replace('v', "");
-  println!("The latest version is v{}", &v);
-  Ok(Version::parse(&v).unwrap())
 }
 
 fn download_package(url: &str, version: &Version) -> Result<Vec<u8>> {

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -2,7 +2,7 @@ use crate::{
   commands::install,
   consts::{DVM_VERSION_CANARY, DVM_VERSION_INVALID, DVM_VERSION_SELF},
   utils::best_version,
-  version::{remote_versions, VersionArg},
+  version::{get_latest_lts_version, remote_versions, VersionArg},
   DvmMeta,
 };
 use anyhow::{Ok, Result};
@@ -46,6 +46,11 @@ pub fn exec(meta: &mut DvmMeta, alias: Option<String>) -> Result<()> {
           install::exec(meta, true, Some(v.to_string())).expect("Install failed");
         }
       }
+      VersionArg::Lts => {
+        let version = get_latest_lts_version()?;
+        install::exec(meta, true, Some(version.to_string())).expect("Install failed");
+        meta.set_version_mapping(alias, version.to_string());
+      }
       VersionArg::Range(r) => {
         let version = best_version(versions.iter().map(AsRef::as_ref), r).unwrap();
         install::exec(meta, true, Some(version.to_string())).expect("Install failed");
@@ -60,6 +65,7 @@ pub fn exec(meta: &mut DvmMeta, alias: Option<String>) -> Result<()> {
 
       let latest = match VersionArg::from_str(alias.required.clone().as_str()).unwrap() {
         VersionArg::Exact(v) => v.to_string(),
+        VersionArg::Lts => get_latest_lts_version()?.to_string(),
         VersionArg::Range(v) => best_version(versions.iter().map(AsRef::as_ref), v).unwrap().to_string(),
       };
 

--- a/src/commands/use_version.rs
+++ b/src/commands/use_version.rs
@@ -1,28 +1,27 @@
 use crate::commands::install;
 use crate::configrc::{rc_get_with_fix, rc_update};
 use crate::consts::{
-  DVM_CONFIGRC_KEY_DENO_VERSION, DVM_CONFIGRC_KEY_REGISTRY_BINARY, DVM_VERSION_CANARY, DVM_VERSION_LATEST,
-  DVM_VERSION_SYSTEM, REGISTRY_OFFICIAL,
+  DVM_CONFIGRC_KEY_DENO_VERSION, DVM_CONFIGRC_KEY_REGISTRY_VERSION, DVM_VERSION_CANARY, DVM_VERSION_LATEST,
+  DVM_VERSION_LTS, DVM_VERSION_SYSTEM, REGISTRY_LIST_OFFICIAL,
 };
 use crate::deno_bin_path;
 use crate::meta::DvmMeta;
 use crate::utils::{best_version, deno_canary_path, deno_version_path, prompt_request, run_with_spinner, update_stub};
 use crate::utils::{is_exact_version, load_dvmrc};
 use crate::version::remote_versions;
-use crate::version::{get_latest_version, VersionArg};
+use crate::version::{get_latest_lts_version, get_latest_remote_version, VersionArg};
 use anyhow::Result;
-use semver::Version;
+use semver::{Version, VersionReq};
 use std::fs;
 use std::path::Path;
 use std::process::Command;
 
 /// using a tag or a specific version
 pub fn exec(meta: &mut DvmMeta, version: Option<String>, write_local: bool) -> Result<()> {
-  let rc_binary_url =
-    rc_get_with_fix(DVM_CONFIGRC_KEY_REGISTRY_BINARY).unwrap_or_else(|_| REGISTRY_OFFICIAL.to_string());
+  let rc_version_url =
+    rc_get_with_fix(DVM_CONFIGRC_KEY_REGISTRY_VERSION).unwrap_or_else(|_| REGISTRY_LIST_OFFICIAL.to_string());
 
-  let version_req: VersionArg;
-  if let Some(ref version) = version {
+  let version_req = if let Some(ref version) = version {
     if version == &DVM_VERSION_CANARY.to_string() {
       let canary_path = deno_canary_path();
       if !canary_path.exists() {
@@ -40,12 +39,14 @@ pub fn exec(meta: &mut DvmMeta, version: Option<String>, write_local: bool) -> R
       std::fs::remove_file(deno_bin_path()).unwrap();
       println!("Deno that was previously installed on your system will be activated now.");
       return Ok(());
-    }
-
-    if is_exact_version(version) {
-      version_req = VersionArg::Exact(Version::parse(version).unwrap());
+    } else if version == DVM_VERSION_LTS {
+      VersionArg::Lts
+    } else if version == DVM_VERSION_LATEST {
+      VersionArg::Range(VersionReq::parse("*").unwrap())
+    } else if is_exact_version(version) {
+      VersionArg::Exact(Version::parse(version).unwrap())
     } else if meta.has_alias(version) {
-      version_req = meta.resolve_version_req(version);
+      meta.resolve_version_req(version)
     } else {
       // dvm will reject for using semver range directly now.
       eprintln!(
@@ -56,23 +57,29 @@ pub fn exec(meta: &mut DvmMeta, version: Option<String>, write_local: bool) -> R
     }
   } else {
     println!("No version input detect, try to use version in .dvmrc file");
-    version_req = load_dvmrc();
+    let version_req = load_dvmrc();
     println!("Using semver range: {}", version_req);
-  }
+    version_req
+  };
 
-  let used_version = if version_req.to_string() == "*" {
-    println!("Checking for latest version");
-    let version = get_latest_version(&rc_binary_url).expect("Get latest version failed");
-    println!("The latest version is v{}", version);
-    version
-  } else {
-    match version_req {
-      VersionArg::Exact(ref v) => v.clone(),
-      VersionArg::Range(ref r) => {
-        println!("Fetching version list");
-        let versions = remote_versions().expect("Fetching version list failed.");
-        best_version(versions.iter().map(AsRef::as_ref), r.clone()).unwrap()
-      }
+  let used_version = match &version_req {
+    VersionArg::Lts => {
+      println!("Checking for latest LTS version");
+      let version = get_latest_lts_version()?;
+      println!("The latest LTS version is v{}", version);
+      version
+    }
+    VersionArg::Range(r) if r.to_string() == "*" => {
+      println!("Checking for latest version");
+      let version = get_latest_remote_version(&rc_version_url)?;
+      println!("The latest version is v{}", version);
+      version
+    }
+    VersionArg::Exact(v) => v.clone(),
+    VersionArg::Range(r) => {
+      println!("Fetching version list");
+      let versions = remote_versions().expect("Fetching version list failed.");
+      best_version(versions.iter().map(AsRef::as_ref), r.clone()).unwrap()
     }
   };
 

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -21,6 +21,7 @@ pub const DVM_CONFIGRC_KEY_REGISTRY_BINARY: &str = "registry_binary";
 pub const DVM_VERSION_SELF: &str = "self";
 pub const DVM_VERSION_CANARY: &str = "canary";
 pub const DVM_VERSION_LATEST: &str = "latest";
+pub const DVM_VERSION_LTS: &str = "lts";
 pub const DVM_VERSION_SYSTEM: &str = "system";
 pub const DVM_VERSION_INVALID: &str = "N/A";
 
@@ -35,8 +36,10 @@ cfg_if::cfg_if! {
 pub const AFTER_HELP: &str = "\x1b[33mEXAMPLE:\x1b[39m
   dvm install 1.3.2     Install v1.3.2 release
   dvm install           Install the latest available version
+  dvm install lts       Install the latest LTS version
   dvm use 1.0.0         Use v1.0.0 release
   dvm use latest        Use the latest alias that comes with dvm, equivalent to *
+  dvm use lts           Use the latest LTS version
   dvm use canary        Use the canary version of the Deno
 
 \x1b[33mNOTE:\x1b[39m

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,8 +1,8 @@
 // Copyright 2022 justjavac. All rights reserved. MIT license.
 use crate::configrc::rc_get_with_fix;
 use crate::consts::{
-  DVM_CACHE_PATH_PREFIX, DVM_CACHE_REMOTE_PATH, DVM_CONFIGRC_KEY_REGISTRY_VERSION, REGISTRY_LATEST_CANARY_PATH,
-  REGISTRY_LATEST_RELEASE_PATH,
+  DVM_CACHE_PATH_PREFIX, DVM_CACHE_REMOTE_PATH, DVM_CONFIGRC_KEY_REGISTRY_VERSION, DVM_VERSION_LTS,
+  REGISTRY_LATEST_CANARY_PATH, REGISTRY_LATEST_RELEASE_PATH,
 };
 use crate::utils::{dvm_root, is_exact_version, is_semver, run_with_spinner};
 use anyhow::Result;
@@ -19,6 +19,7 @@ use std::str::FromStr;
 use std::string::String;
 
 pub const DVM: &str = env!("CARGO_PKG_VERSION");
+const DENO_RELEASES_LTS_SEARCH: &str = "https://github.com/denoland/deno/releases?q=LTS";
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Cached {
@@ -30,6 +31,7 @@ pub struct Cached {
 pub enum VersionArg {
   Exact(Version),
   Range(VersionReq),
+  Lts,
 }
 
 impl std::fmt::Display for VersionArg {
@@ -37,6 +39,7 @@ impl std::fmt::Display for VersionArg {
     match self {
       VersionArg::Exact(version) => f.write_str(version.to_string().as_str()),
       VersionArg::Range(version) => f.write_str(version.to_string().as_str()),
+      VersionArg::Lts => f.write_str(DVM_VERSION_LTS),
     }
   }
 }
@@ -45,7 +48,9 @@ impl FromStr for VersionArg {
   type Err = ();
 
   fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-    if is_exact_version(s) {
+    if s == DVM_VERSION_LTS {
+      Ok(VersionArg::Lts)
+    } else if is_exact_version(s) {
       Version::parse(s).map(VersionArg::Exact).map_err(|_| ())
     } else {
       VersionReq::parse(s)
@@ -167,6 +172,24 @@ pub fn get_latest_version(registry: &str) -> Result<Version> {
   Ok(Version::parse(&v).unwrap())
 }
 
+pub fn get_latest_remote_version(registry: &str) -> Result<Version> {
+  let response = tinyget::get(registry).send()?;
+  if response.status_code >= 400 {
+    anyhow::bail!("Failed to fetch Deno versions: {}", response.status_code);
+  }
+  latest_version_from_versions_json(response.as_str()?)
+}
+
+pub fn get_latest_lts_version() -> Result<Version> {
+  let response = tinyget::get(DENO_RELEASES_LTS_SEARCH)
+    .with_header("User-Agent", "dvm")
+    .send()?;
+  if response.status_code >= 400 {
+    anyhow::bail!("Failed to fetch Deno LTS releases: {}", response.status_code);
+  }
+  latest_lts_version_from_releases_html(response.as_str()?)
+}
+
 pub fn get_latest_canary(registry: &str) -> Result<String> {
   let response = tinyget::get(format!("{}{}", registry, REGISTRY_LATEST_CANARY_PATH)).send()?;
 
@@ -191,4 +214,76 @@ where
       .filter(|s| version_req.matches(s))
       .max(),
   )
+}
+
+fn latest_version_from_versions_json(content: &str) -> Result<Version> {
+  let versions = cli_versions_from_versions_json(content)?;
+  versions
+    .iter()
+    .filter_map(|s| Version::parse(s).ok())
+    .filter(|version| version.pre.is_empty())
+    .max()
+    .ok_or_else(|| anyhow::anyhow!("No stable Deno versions found"))
+}
+
+fn cli_versions_from_versions_json(content: &str) -> Result<Vec<String>> {
+  let json: serde_json::Value = serde_json::from_str(content)?;
+  let Some(cli_versions) = json.get("cli").and_then(|value| value.as_array()) else {
+    anyhow::bail!("The remote version list is missing cli versions");
+  };
+
+  Ok(
+    cli_versions
+      .iter()
+      .filter_map(|value| value.as_str())
+      .map(|version| version.trim_start_matches('v').to_string())
+      .collect(),
+  )
+}
+
+fn latest_lts_version_from_releases_html(content: &str) -> Result<Version> {
+  content
+    .match_indices("/denoland/deno/releases/tag/v")
+    .filter_map(|(index, _)| {
+      let version_start = index + "/denoland/deno/releases/tag/v".len();
+      let version = content[version_start..]
+        .chars()
+        .take_while(|ch| ch.is_ascii_alphanumeric() || *ch == '.' || *ch == '-')
+        .collect::<String>();
+      Version::parse(&version).ok()
+    })
+    .filter(|version| version.pre.is_empty())
+    .max()
+    .ok_or_else(|| anyhow::anyhow!("No Deno LTS release found"))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn latest_remote_version_uses_highest_stable_cli_version() {
+    let content = r#"{
+      "cli": ["v2.1.11", "v2.2.8", "v3.0.0-rc.1", "v2.2.7"]
+    }"#;
+
+    assert_eq!(
+      latest_version_from_versions_json(content).unwrap(),
+      Version::parse("2.2.8").unwrap()
+    );
+  }
+
+  #[test]
+  fn latest_lts_version_uses_highest_release_search_result() {
+    let content = r#"
+      <a href="/denoland/deno/releases/tag/v2.2.13">v2.2.13</a>
+      <a href="/denoland/deno/releases/tag/v2.2.15">v2.2.15</a>
+      <a href="/denoland/deno/releases/tag/v2.0.0-rc.1">v2.0.0-rc.1</a>
+    "#;
+
+    assert_eq!(
+      latest_lts_version_from_releases_html(content).unwrap(),
+      Version::parse("2.2.15").unwrap()
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- Resolve `dvm install` / `dvm install latest` from the configured `versions.json` and choose the highest stable CLI version
- Add `lts` version resolution for install/use/exec/upgrade flows
- Preserve `deno_version=lts` in `.dvmrc` by representing LTS as a first-class `VersionArg`
- Document `install lts` and `use lts` examples

Fixes #224

## Tests
- `cargo test`
- `cargo build`
- Verified with temporary `.dvmrc` and `DVM_DIR` that `install latest` resolves v2.9.0 and `install lts` resolves v2.2.15 before download
- Verified `use latest`, `use lts`, and no-arg `use` with `deno_version=lts` resolve the expected versions before prompting to install