### PR TITLE
fix: install Windows dvm from release assets

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -16,7 +16,7 @@ $DvmZip = "$BinDir\dvm.zip"
 $DvmExe = "$BinDir\dvm.exe"
 $DvmExeOldName = "dvm.exe.old"
 $DvmExeOld = "$BinDir\$DvmExeOldName"
-$DvmUri = "https://cdn.jsdelivr.net/gh/justjavac/dvm_releases@main/dvm-x86_64-pc-windows-msvc.zip"
+$DvmUri = "https://github.com/justjavac/dvm/releases/latest/download/dvm-x86_64-pc-windows-msvc.zip"
 
 if (!(Test-Path $BinDir)) {
   New-Item $BinDir -ItemType Directory | Out-Null


### PR DESCRIPTION
## Summary
- Update the PowerShell installer to download `dvm-x86_64-pc-windows-msvc.zip` from GitHub Releases `latest/download`
- Stop relying on the stale jsDelivr `justjavac/dvm_releases@main` artifact for Windows installs and self-upgrades

Fixes #221

## Tests
- Parsed `install.ps1` with PowerShell parser
- Downloaded the new Windows release zip and verified `dvm.exe -V` prints `dvm 1.9.3`