### PR TITLE
fix: run upgrade self installer from temp file

### DIFF
--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -103,15 +103,21 @@ fn upgrade_self() -> Result<()> {
       fs::write(&tmp, script)?;
       let mut cmd = std::process::Command::new("powershell");
       cmd.arg("-ExecutionPolicy").arg("Bypass").arg("-File").arg(tmp);
-      cmd.status()?;
+      let status = cmd.status()?;
+      if !status.success() {
+        anyhow::bail!("Failed to upgrade dvm");
+      }
     } else {
       let url = "https://raw.githubusercontent.com/justjavac/dvm/main/install.sh";
       let script = tinyget::get(url).send()?;
       let script = script.as_str()?;
       let tmp = tempfile::tempdir()?;
       let tmp = tmp.path().join("install.sh");
-      fs::write(tmp, script)?;
-      std::process::Command::new("bash").arg(script).status()?;
+      fs::write(&tmp, script)?;
+      let status = std::process::Command::new("bash").arg(&tmp).status()?;
+      if !status.success() {
+        anyhow::bail!("Failed to upgrade dvm");
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Run the downloaded Unix self-upgrade installer from the temporary script file instead of passing the full script body as the bash argument
- Check installer exit status on both Windows and Unix paths and report a normal error on failure

Fixes #220

## Tests
- `cargo test`
- Attempted `cargo check --target x86_64-unknown-linux-gnu`, but this Windows environment lacks `perl` and `x86_64-linux-gnu-gcc` needed to build vendored OpenSSL for that target