### PR TITLE
fix: trim dvmrc config values

### DIFF
--- a/src/configrc.rs
+++ b/src/configrc.rs
@@ -138,8 +138,8 @@ fn rc_parse(content: &str) -> Vec<(&str, &str)> {
     .filter(|it| it.contains('='))
     .map(|line| {
       let mut parts = line.splitn(2, '=');
-      let k = parts.next().unwrap();
-      let v = parts.next().unwrap_or("");
+      let k = parts.next().unwrap().trim();
+      let v = parts.next().unwrap_or("").trim();
       (k, v)
     })
     .collect::<Vec<_>>();
@@ -206,5 +206,20 @@ pub fn rc_unlink(is_local: bool) -> io::Result<()> {
     let home_dir = dirs::home_dir().ok_or_else(|| io::Error::from(io::ErrorKind::NotFound))?;
     let rc_file = home_dir.join(DVM_CONFIGRC_FILENAME);
     fs::remove_file(rc_file)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn rc_parse_trims_keys_and_values() {
+    let config = rc_parse(" deno_version = 1.2.3 \nregistry_binary = https://example.com/ \n");
+
+    assert_eq!(
+      config,
+      vec![("deno_version", "1.2.3"), ("registry_binary", "https://example.com/")]
+    );
   }
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -48,6 +48,7 @@ impl FromStr for VersionArg {
   type Err = ();
 
   fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+    let s = s.trim();
     if s == DVM_VERSION_LTS {
       Ok(VersionArg::Lts)
     } else if is_exact_version(s) {
@@ -285,5 +286,14 @@ mod tests {
       latest_lts_version_from_releases_html(content).unwrap(),
       Version::parse("2.2.15").unwrap()
     );
+  }
+
+  #[test]
+  fn version_arg_trims_input() {
+    assert_eq!(
+      VersionArg::from_str(" 1.2.3 \n").unwrap(),
+      VersionArg::Exact(Version::parse("1.2.3").unwrap())
+    );
+    assert_eq!(VersionArg::from_str(" lts \n").unwrap(), VersionArg::Lts);
   }
 }


### PR DESCRIPTION
## Summary
- Trim keys and values when parsing `.dvmrc`/config files
- Trim version arguments before resolving exact versions, ranges, and `lts`
- Add regression tests for whitespace in config parsing and version parsing

Fixes #211

## Tests
- `cargo test`
- `cargo build`
- Verified `dvm use` with a temporary `.dvmrc` containing ` deno_version = 1.2.3 ` resolves `1.2.3` instead of falling back to latest