### PR TITLE
fix: use bashrc for Linux installer path

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -48,9 +48,16 @@ fi
 cd "$dvm_bin_dir"
 chmod +x "$exe"
 
-case $SHELL in
-/bin/zsh) shell_profile=".zshrc" ;;
-*) shell_profile=".bash_profile" ;;
+case $(basename "$SHELL") in
+zsh) shell_profile=".zshrc" ;;
+bash)
+	if [ "$(uname -s)" = "Darwin" ]; then
+		shell_profile=".bash_profile"
+	else
+		shell_profile=".bashrc"
+	fi
+	;;
+*) shell_profile=".profile" ;;
 esac
 
 if [ ! $DVM_DIR ];then


### PR DESCRIPTION
## Summary
- Write Linux bash installer exports to `.bashrc` instead of `.bash_profile`
- Keep macOS bash using `.bash_profile`
- Keep zsh using `.zshrc`, and fall back to `.profile` for other shells

Fixes #202

## Tests
- `bash -n install.sh`