### PR TITLE
fix: point install docs at raw GitHub URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ the [releases page](https://github.com/justjavac/dvm/releases).
 **With Shell:**
 
 ```sh
-curl -fsSL https://dvm.deno.dev | sh
+curl -fsSL https://raw.githubusercontent.com/justjavac/dvm/main/install.sh | sh
 ```
 
 **With PowerShell:**
 
 ```powershell
-irm https://dvm.deno.dev | iex
+irm https://raw.githubusercontent.com/justjavac/dvm/main/install.ps1 | iex
 ```
 
 ## Usage
@@ -145,7 +145,7 @@ The program [`unzip`](https://linux.die.net/man/1/unzip) is a requirement for
 the Shell installer.
 
 ```sh
-$ curl -fsSL https://deno.land/x/dvm/install.sh | sh
+$ curl -fsSL https://raw.githubusercontent.com/justjavac/dvm/main/install.sh | sh
 Error: unzip is required to install dvm (see: https://github.com/justjavac/dvm#unzip-is-required).
 ```
 

--- a/README_zh-cn.md
+++ b/README_zh-cn.md
@@ -9,13 +9,13 @@
 **Shell 安装：**
 
 ```sh
-curl -fsSL https://deno.land/x/dvm/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/justjavac/dvm/main/install.sh | sh
 ```
 
 **PowerShell 安装：**
 
 ```powershell
-irm https://deno.land/x/dvm/install.ps1 | iex
+irm https://raw.githubusercontent.com/justjavac/dvm/main/install.ps1 | iex
 ```
 
 **设置中文镜像：`dvm registry cn`**。
@@ -143,7 +143,7 @@ deno v1.2.0 is not installed. Use `dvm install 1.2.0` to install it first.
 此项目需要依赖 [`unzip`](https://linux.die.net/man/1/unzip) 进行 Shell 安装。
 
 ```sh
-$ curl -fsSL https://deno.land/x/dvm/install.sh | sh
+$ curl -fsSL https://raw.githubusercontent.com/justjavac/dvm/main/install.sh | sh
 Error: unzip is required to install dvm (see: https://github.com/justjavac/dvm#unzip-is-required).
 ```
 

--- a/main.ts
+++ b/main.ts
@@ -14,10 +14,10 @@ Deno.serve(async (req: Request) => {
 
   Install With Shell:
 
-    curl -fsSL https://dvm.deno.dev | sh
+    curl -fsSL https://raw.githubusercontent.com/justjavac/dvm/main/install.sh | sh
   
   Install With PowerShell:
 
-    irm https://dvm.deno.dev | iex
+    irm https://raw.githubusercontent.com/justjavac/dvm/main/install.ps1 | iex
   `);
 });

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -152,7 +152,7 @@ mod tests {
 
   #[test]
   fn test_best_version() {
-    let versions = vec![
+    let versions = [
       "0.8.5",
       "0.8.0",
       "0.9.0",

--- a/tests/install_docs.rs
+++ b/tests/install_docs.rs
@@ -1,0 +1,55 @@
+//! Regression tests for <https://github.com/justjavac/dvm/issues/243>.
+//!
+//! `https://dvm.deno.dev` was a Deno Deploy Classic deployment that stopped
+//! serving on 2026-07-20, and `https://deno.land/x/dvm` only serves stale
+//! tagged snapshots. The documented install commands must therefore fetch
+//! `install.sh` / `install.ps1` from raw.githubusercontent.com, where they
+//! always track the `main` branch.
+
+use std::path::PathBuf;
+
+const SH_URL: &str = "https://raw.githubusercontent.com/justjavac/dvm/main/install.sh";
+const PS_URL: &str = "https://raw.githubusercontent.com/justjavac/dvm/main/install.ps1";
+
+const READMES: [&str; 2] = ["README.md", "README_zh-cn.md"];
+
+fn repo_root() -> PathBuf {
+  PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn read_readme(name: &str) -> String {
+  std::fs::read_to_string(repo_root().join(name)).unwrap_or_else(|e| panic!("failed to read {name}: {e}"))
+}
+
+#[test]
+fn readmes_use_raw_github_install_urls() {
+  for name in READMES {
+    let content = read_readme(name);
+    assert!(content.contains(SH_URL), "{name} must install via {SH_URL}");
+    assert!(content.contains(PS_URL), "{name} must install via {PS_URL}");
+  }
+}
+
+#[test]
+fn readmes_do_not_reference_dead_install_hosts() {
+  for name in READMES {
+    let content = read_readme(name);
+    assert!(
+      !content.contains("dvm.deno.dev"),
+      "{name} must not reference the sunset Deno Deploy Classic host"
+    );
+    assert!(
+      !content.contains("deno.land/x/dvm"),
+      "{name} must not reference the stale deno.land/x snapshot"
+    );
+  }
+}
+
+#[test]
+fn install_scripts_exist_at_repo_root() {
+  // The raw URLs above resolve to these files on the `main` branch.
+  for name in ["install.sh", "install.ps1"] {
+    let path = repo_root().join(name);
+    assert!(path.is_file(), "{} must exist", path.display());
+  }
+}


### PR DESCRIPTION
## 问题

#243 — `https://dvm.deno.dev` 由 Deno Deploy Classic 托管，Classic 于 2026-07-20 停服，安装命令 `curl https://dvm.deno.dev | sh` / `irm https://dvm.deno.dev | iex` 返回 404 DEPLOYMENT_NOT_FOUND，新用户无法安装。

## 修复

README（中英）与 `main.ts` 回退文本中的安装地址改为直接从 raw.githubusercontent.com 获取 `install.sh` / `install.ps1`（随 main 分支更新，无外部托管依赖）。顺带统一了中文 README 中过时的 `deno.land/x/dvm` 快照地址。

## 测试

新增 `tests/install_docs.rs`：

- 两份 README 必须包含 raw GitHub 安装地址；
- 两份 README 不得再引用已停服的 `dvm.deno.dev` 或过时快照 `deno.land/x/dvm`；
- `install.sh` / `install.ps1` 必须存在于仓库根目录（raw URL 的解析目标）。

已手动验证两个 raw URL 均返回 200。

Closes #243