### PR TITLE
feat: warn when dvm's deno is shadowed on PATH

### DIFF
--- a/src/commands/use_version.rs
+++ b/src/commands/use_version.rs
@@ -7,10 +7,11 @@ use crate::consts::{
 use crate::deno_bin_path;
 use crate::meta::DvmMeta;
 use crate::utils::{best_version, deno_canary_path, deno_version_path, prompt_request, run_with_spinner, update_stub};
-use crate::utils::{is_exact_version, load_dvmrc};
+use crate::utils::{is_exact_version, load_dvmrc, DenoResolution};
 use crate::version::remote_versions;
 use crate::version::{get_latest_lts_version, get_latest_remote_version, VersionArg};
 use anyhow::Result;
+use colored::Colorize;
 use semver::{Version, VersionReq};
 use std::fs;
 use std::path::Path;
@@ -129,7 +130,9 @@ pub fn use_canary_bin_path(local: bool) -> Result<()> {
     rc_update(local, DVM_CONFIGRC_KEY_DENO_VERSION, DVM_VERSION_CANARY)?;
 
     Ok(())
-  })
+  })?;
+  warn_if_deno_shadowed();
+  Ok(())
 }
 
 pub fn use_this_bin_path(exe_path: &Path, version: &Version, raw_version: String, local: bool) -> Result<()> {
@@ -147,7 +150,41 @@ pub fn use_this_bin_path(exe_path: &Path, version: &Version, raw_version: String
 
     rc_update(local, DVM_CONFIGRC_KEY_DENO_VERSION, raw_version.as_str())?;
     Ok(())
-  })
+  })?;
+  warn_if_deno_shadowed();
+  Ok(())
+}
+
+/// `dvm use` only rewrites the hard link inside dvm's bin directory. When
+/// another deno sits earlier on `PATH` (winget, scoop, the official
+/// installer, ...), `deno` keeps resolving to that other installation and the
+/// switch silently does nothing — see
+/// <https://github.com/justjavac/dvm/issues/244>. Warn loudly in that case.
+fn warn_if_deno_shadowed() {
+  let bin_dir = crate::utils::dvm_bin_dir();
+  match crate::utils::deno_resolution() {
+    DenoResolution::Dvm => {}
+    DenoResolution::Shadowed(path) => eprintln!(
+      "{}",
+      format!(
+        "Warning: `deno` resolves to `{}` instead of `{}`.\n\
+         The selected version will not be used. Run `dvm doctor` and restart your shell, \
+         or move dvm's bin directory earlier in your PATH.",
+        path.display(),
+        bin_dir.display()
+      )
+      .yellow()
+    ),
+    DenoResolution::NotOnPath => eprintln!(
+      "{}",
+      format!(
+        "Warning: `deno` was not found on your PATH.\n\
+         Add `{}` to your PATH (or run `dvm doctor`), then restart your shell.",
+        bin_dir.display()
+      )
+      .yellow()
+    ),
+  }
 }
 
 fn check_exe(exe_path: &Path, expected_version: &Version) -> Result<()> {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,6 +7,7 @@ use semver::{Version, VersionReq};
 use std::env;
 use std::fs::write;
 use std::io::{stdin, stdout, BufReader, Read, Write};
+use std::path::Path;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::time;
@@ -130,6 +131,60 @@ pub fn deno_bin_path() -> PathBuf {
   dvm_bin_dir.join(DENO_EXE)
 }
 
+/// dvm's bin directory, i.e. the directory that must come first on `PATH`
+/// for the version selected by `dvm use` to win.
+pub fn dvm_bin_dir() -> PathBuf {
+  deno_bin_path().parent().unwrap().to_path_buf()
+}
+
+/// Where the `deno` command found on `PATH` actually points, relative to
+/// dvm's bin directory.
+#[derive(Debug, PartialEq, Eq)]
+pub enum DenoResolution {
+  /// `deno` resolves into dvm's bin directory — version switching works.
+  Dvm,
+  /// `deno` resolves to another installation that shadows dvm's hard link,
+  /// e.g. a deno installed by winget/scoop that sits earlier on `PATH`.
+  Shadowed(PathBuf),
+  /// No `deno` on `PATH` at all.
+  NotOnPath,
+}
+
+/// Resolve `deno` on the current `PATH` and classify it against dvm's bin
+/// directory. See <https://github.com/justjavac/dvm/issues/244>.
+pub fn deno_resolution() -> DenoResolution {
+  classify_deno_resolution(which::which("deno").ok().as_deref(), &dvm_bin_dir())
+}
+
+fn classify_deno_resolution(resolved: Option<&Path>, bin_dir: &Path) -> DenoResolution {
+  match resolved {
+    None => DenoResolution::NotOnPath,
+    Some(path) if path_contains_dir(path, bin_dir) => DenoResolution::Dvm,
+    Some(path) => DenoResolution::Shadowed(path.to_path_buf()),
+  }
+}
+
+/// Is `path` inside directory `dir`? Component-aware, so `/a/bin2/x` does not
+/// count as inside `/a/bin`. Case-insensitive on Windows.
+#[cfg(not(windows))]
+fn path_contains_dir(path: &Path, dir: &Path) -> bool {
+  path.starts_with(dir)
+}
+
+/// Is `path` inside directory `dir`? Component-aware, so `/a/bin2/x` does not
+/// count as inside `/a/bin`. Case-insensitive on Windows.
+#[cfg(windows)]
+fn path_contains_dir(path: &Path, dir: &Path) -> bool {
+  fn normalize(p: &Path) -> String {
+    p.to_string_lossy().replace('/', "\\").to_lowercase()
+  }
+  let mut dir = normalize(dir);
+  if !dir.ends_with('\\') {
+    dir.push('\\');
+  }
+  normalize(path).starts_with(&dir)
+}
+
 pub fn deno_version_path(version: &Version) -> PathBuf {
   let dvm_dir = dvm_root().join(format!("{}/{}", DVM_CACHE_PATH_PREFIX, version));
   dvm_dir.join(DENO_EXE)
@@ -174,5 +229,41 @@ mod tests {
       best_version(versions.iter().map(AsRef::as_ref), VersionReq::parse("~0.8").unwrap()),
       Some(Version::parse("0.8.5").unwrap())
     );
+  }
+
+  #[test]
+  fn deno_resolution_classification() {
+    let bin_dir = Path::new("/home/u/.dvm/bin");
+
+    assert_eq!(classify_deno_resolution(None, bin_dir), DenoResolution::NotOnPath);
+    assert_eq!(
+      classify_deno_resolution(Some(Path::new("/home/u/.dvm/bin/deno")), bin_dir),
+      DenoResolution::Dvm
+    );
+    assert_eq!(
+      classify_deno_resolution(Some(Path::new("/usr/local/bin/deno")), bin_dir),
+      DenoResolution::Shadowed(PathBuf::from("/usr/local/bin/deno"))
+    );
+  }
+
+  #[test]
+  fn path_contains_dir_is_component_aware() {
+    let bin_dir = Path::new("/home/u/.dvm/bin");
+
+    assert!(path_contains_dir(Path::new("/home/u/.dvm/bin/deno"), bin_dir));
+    // `bin2` merely shares a string prefix with `bin` — must not match.
+    assert!(!path_contains_dir(Path::new("/home/u/.dvm/bin2/deno"), bin_dir));
+    // A path shorter than the bin dir cannot be inside it.
+    assert!(!path_contains_dir(Path::new("/home/u/.dvm"), bin_dir));
+  }
+
+  #[cfg(windows)]
+  #[test]
+  fn path_contains_dir_is_case_insensitive_on_windows() {
+    let bin_dir = Path::new("C:\\Users\\me\\.dvm\\bin");
+
+    assert!(path_contains_dir(Path::new("c:\\users\\me\\.dvm\\bin\\deno.exe"), bin_dir));
+    assert!(path_contains_dir(Path::new("C:/Users/me/.dvm/bin/deno.exe"), bin_dir));
+    assert!(!path_contains_dir(Path::new("C:\\Users\\me\\.dvm\\bin2\\deno.exe"), bin_dir));
   }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -262,8 +262,14 @@ mod tests {
   fn path_contains_dir_is_case_insensitive_on_windows() {
     let bin_dir = Path::new("C:\\Users\\me\\.dvm\\bin");
 
-    assert!(path_contains_dir(Path::new("c:\\users\\me\\.dvm\\bin\\deno.exe"), bin_dir));
+    assert!(path_contains_dir(
+      Path::new("c:\\users\\me\\.dvm\\bin\\deno.exe"),
+      bin_dir
+    ));
     assert!(path_contains_dir(Path::new("C:/Users/me/.dvm/bin/deno.exe"), bin_dir));
-    assert!(!path_contains_dir(Path::new("C:\\Users\\me\\.dvm\\bin2\\deno.exe"), bin_dir));
+    assert!(!path_contains_dir(
+      Path::new("C:\\Users\\me\\.dvm\\bin2\\deno.exe"),
+      bin_dir
+    ));
   }
 }


### PR DESCRIPTION
## 问题

#244 — Windows 上 `dvm use 1.46.3` 显示 "Now using deno 1.46.3"，但 `deno -v` 仍是 2.9.4。原因：`dvm use` 只重写 `~/.dvm/bin` 里的硬链接，当另一个 deno（winget/scoop/官方安装包）在 PATH 中排在更前面时，`deno` 永远解析到那个安装，切换静默失效。

## 修复

切换成功后（`use_this_bin_path` / `use_canary_bin_path`，含 `dvm install` 的联动切换），检查 `deno` 在 PATH 上的解析结果：

- 解析到 dvm bin 目录之外 → 黄色警告，给出实际解析路径与 dvm bin 目录，提示运行 `dvm doctor` 或调整 PATH 顺序；
- PATH 上找不到 deno → 警告并提示把 dvm bin 加入 PATH；
- 正常解析 → 静默。

路径比较是组件级的（`bin2` 不会误匹配 `bin`），Windows 下大小写不敏感并兼容 `/` 分隔符。

## 测试

- `utils.rs` 新增单元测试：三种解析分类、组件级前缀比较（`bin2` 反例）、Windows 大小写/分隔符归一化（windows cfg，CI windows runner 执行）；
- 本机端到端冒烟：临时 `DVM_DIR` + 假 deno 占 PATH → 出现 Shadowed 警告；PATH 无 deno → 出现 NotOnPath 警告；dvm bin 置前 → 无警告且 `deno --version` 为切换后的 1.46.3。

Closes #244